### PR TITLE
Add linter and fix lint issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,93 @@
+# This file was inspired by the golangci-lint one:
+# https://github.com/golangci/golangci-lint/blob/master/.golangci.yml
+run:
+  # default concurrency is a available CPU number
+  concurrency: 4
+
+  # timeout for analysis, e.g. 30s, 5m, default is 1m
+  timeout: 5m
+linters-settings:
+  govet:
+    check-shadowing: true
+  golint:
+    min-confidence: 0
+  gocyclo:
+    min-complexity: 15
+  maligned:
+    suggest-new: true
+  dupl:
+    threshold: 100
+  goconst:
+    min-len: 2
+    min-occurrences: 2
+  misspell:
+    locale: UK
+  lll:
+    line-length: 140
+  gofmt:
+    simplify: false
+  gocritic:
+    enabled-tags:
+      - diagnostic
+      - experimental
+      - opinionated
+      - performance
+      - style
+    disabled-checks:
+      - wrapperFunc
+      - dupImport # https://github.com/go-critic/go-critic/issues/845
+      - ifElseChain
+      - octalLiteral
+      - hugeParam
+  funlen:
+  # lines: 100
+  # statements: 100
+
+linters:
+  # please, do not use `enable-all`: it's deprecated and will be removed soon.
+  # inverted configuration with `enable-all` and `disable` is not scalable during updates of golangci-lint
+  disable-all: true
+  enable:
+    - deadcode
+    - depguard
+    - dogsled
+    - errcheck
+    - gochecknoinits
+    - goconst
+    - gocritic
+    - gocyclo
+    - gofmt
+    - goimports
+    - revive
+    - gosec
+    - gosimple
+    - govet
+    - ineffassign
+    - nakedret
+    - staticcheck
+    - structcheck
+    - stylecheck
+    - typecheck
+    - unconvert
+    - unused
+    - varcheck
+    - whitespace
+    - gocognit
+    - prealloc
+
+issues:
+  exclude-rules:
+    - path: _test\.go
+      linters:
+        - gocyclo
+        - errcheck
+        - dupl
+        - gosec
+  new: false
+
+# golangci.com configuration
+# https://github.com/golangci/golangci/wiki/Configuration
+service:
+  golangci-lint-version: 1.43.x # use the fixed version to not introduce new linters unexpectedly
+  prepare:
+    - echo "here I can run custom commands, but no preparation needed for this repo"

--- a/cmd/producer/main.go
+++ b/cmd/producer/main.go
@@ -53,7 +53,9 @@ func main() {
 		}
 
 		// Send bytes to Output channel, after calling Initialise just in case it is not initialised.
-		kafkaProducer.Initialise(ctx)
+		if err := kafkaProducer.Initialise(ctx); err != nil {
+			log.Warn(ctx, "failed to initialise kafka producer")
+		}
 		kafkaProducer.Channels().Output <- bytes
 	}
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -12,13 +12,10 @@ func TestConfig(t *testing.T) {
 	Convey("Given an environment with no environment variables set", t, func() {
 		os.Clearenv()
 		cfg, err := Get()
-
 		Convey("When the config values are retrieved", func() {
-
 			Convey("Then there should be no error returned", func() {
 				So(err, ShouldBeNil)
 			})
-
 			Convey("Then the values should be set to the expected defaults", func() {
 				So(cfg.BindAddr, ShouldEqual, "localhost:25800")
 				So(cfg.GracefulShutdownTimeout, ShouldEqual, 5*time.Second)

--- a/event/consumer.go
+++ b/event/consumer.go
@@ -19,7 +19,6 @@ type Handler interface {
 
 // Consume converts messages to event instances, and pass the event to the provided handler.
 func Consume(ctx context.Context, messageConsumer kafka.IConsumerGroup, handler Handler, cfg *config.Config) {
-
 	// consume loop, to be executed by each worker
 	var consume = func(workerID int) {
 		for {
@@ -48,7 +47,6 @@ func Consume(ctx context.Context, messageConsumer kafka.IConsumerGroup, handler 
 // processMessage unmarshals the provided kafka message into an event and calls the handler.
 // After the message is handled, it is committed.
 func processMessage(ctx context.Context, message kafka.Message, handler Handler, cfg *config.Config) {
-
 	// unmarshal - commit on failure (consuming the message again would result in the same error)
 	event, err := unmarshal(message)
 	if err != nil {

--- a/event/consumer_test.go
+++ b/event/consumer_test.go
@@ -27,9 +27,7 @@ var testEvent = models.ContentPublished{
 }
 
 func TestConsume(t *testing.T) {
-
 	Convey("Given kafka consumer and event handler mocks", t, func() {
-
 		cgChannels := &kafka.ConsumerGroupChannels{Upstream: make(chan kafka.Message, 2)}
 		mockConsumer := &kafkatest.IConsumerGroupMock{
 			ChannelsFunc: func() *kafka.ConsumerGroupChannels { return cgChannels },
@@ -44,21 +42,16 @@ func TestConsume(t *testing.T) {
 		}
 
 		Convey("And a kafka message with the valid schema being sent to the Upstream channel", func() {
-
 			message := kafkatest.NewMessage(marshal(testEvent), 0)
 			mockConsumer.Channels().Upstream <- message
-
 			Convey("When consume message is called", func() {
-
 				handlerWg.Add(1)
 				event.Consume(testCtx, mockConsumer, mockEventHandler, &config.Config{KafkaNumWorkers: 1})
 				handlerWg.Wait()
-
 				Convey("An event is sent to the mockEventHandler ", func() {
 					So(len(mockEventHandler.HandleCalls()), ShouldEqual, 1)
 					So(*mockEventHandler.HandleCalls()[0].ContentPublished, ShouldResemble, testEvent)
 				})
-
 				Convey("The message is committed and the consumer is released", func() {
 					<-message.UpstreamDone()
 					So(len(message.CommitCalls()), ShouldEqual, 1)
@@ -68,23 +61,18 @@ func TestConsume(t *testing.T) {
 		})
 
 		Convey("And two kafka messages, one with a valid schema and one with an invalid schema", func() {
-
 			validMessage := kafkatest.NewMessage(marshal(testEvent), 1)
 			invalidMessage := kafkatest.NewMessage([]byte("invalid schema"), 0)
 			mockConsumer.Channels().Upstream <- invalidMessage
 			mockConsumer.Channels().Upstream <- validMessage
-
 			Convey("When consume messages is called", func() {
-
 				handlerWg.Add(1)
 				event.Consume(testCtx, mockConsumer, mockEventHandler, &config.Config{KafkaNumWorkers: 1})
 				handlerWg.Wait()
-
 				Convey("Only the valid event is sent to the mockEventHandler ", func() {
 					So(len(mockEventHandler.HandleCalls()), ShouldEqual, 1)
 					So(*mockEventHandler.HandleCalls()[0].ContentPublished, ShouldResemble, testEvent)
 				})
-
 				Convey("Only the valid message is committed, but the consumer is released for both messages", func() {
 					<-validMessage.UpstreamDone()
 					<-invalidMessage.UpstreamDone()
@@ -105,7 +93,6 @@ func TestConsume(t *testing.T) {
 			mockConsumer.Channels().Upstream <- message
 
 			Convey("When consume message is called", func() {
-
 				handlerWg.Add(1)
 				event.Consume(testCtx, mockConsumer, mockEventHandler, &config.Config{KafkaNumWorkers: 1})
 				handlerWg.Wait()

--- a/event/consumer_test.go
+++ b/event/consumer_test.go
@@ -126,8 +126,8 @@ func TestConsume(t *testing.T) {
 }
 
 // marshal helper method to marshal a event into a []byte
-func marshal(event models.ContentPublished) []byte {
-	bytes, err := schema.ContentPublishedEvent.Marshal(event)
+func marshal(cpEvent models.ContentPublished) []byte {
+	bytes, err := schema.ContentPublishedEvent.Marshal(cpEvent)
 	So(err, ShouldBeNil)
 	return bytes
 }

--- a/event/producer_test.go
+++ b/event/producer_test.go
@@ -35,11 +35,9 @@ var (
 
 func TestProducer_SearchDataImport(t *testing.T) {
 	Convey("Given SearchDataImportProducer has been configured correctly", t, func() {
-
 		pChannels := &kafka.ProducerChannels{
 			Output: make(chan []byte, 1),
 		}
-
 		kafkaProducerMock := &kafkatest.IProducerMock{
 			ChannelsFunc: func() *kafka.ProducerChannels {
 				return pChannels
@@ -52,13 +50,12 @@ func TestProducer_SearchDataImport(t *testing.T) {
 			},
 		}
 
-		//event is message
+		// event is message
 		searchDataImportProducer := event.SearchDataImportProducer{
 			Producer:   kafkaProducerMock,
 			Marshaller: marshallerMock,
 		}
 		Convey("When SearchDataImport is called on the event producer", func() {
-
 			err := searchDataImportProducer.SearchDataImport(ctx, expectedSearchDataImportEvent)
 			So(err, ShouldBeNil)
 
@@ -84,7 +81,6 @@ func TestProducer_SearchDataImport(t *testing.T) {
 
 func TestProducer_SearchDataImport_MarshalErr(t *testing.T) {
 	Convey("Given InstanceCompletedProducer has been configured correctly", t, func() {
-
 		pChannels := &kafka.ProducerChannels{
 			Output: make(chan []byte, 1),
 		}
@@ -101,7 +97,7 @@ func TestProducer_SearchDataImport_MarshalErr(t *testing.T) {
 			},
 		}
 
-		//event is message
+		// event is message
 		searchDataImportProducer := event.SearchDataImportProducer{
 			Producer:   kafkaProducerMock,
 			Marshaller: marshallerMock,

--- a/features/publish_data.feature
+++ b/features/publish_data.feature
@@ -1,0 +1,7 @@
+Feature: Data extractor should listen to the relevant topic and publish extracted data
+    Scenario: When searching for the extracted data I get the expected result
+        Given I send a kafka event to content published topic
+         | URI                | DataType             |   CollectionID  |
+         | some_uri           | some_datatype        |    123          |
+        When The kafka event is processed
+        Then I should receive the published data

--- a/features/steps/component.go
+++ b/features/steps/component.go
@@ -27,15 +27,12 @@ type Component struct {
 	KafkaConsumer kafka.IConsumerGroup
 	KafkaProducer kafka.IProducer
 	zebedeeClient clients.ZebedeeClient
-	killChannel   chan os.Signal
-	apiFeature    *componenttest.APIFeature
 	errorChan     chan error
 	svc           *service.Service
 	cfg           *config.Config
 }
 
 func NewComponent() *Component {
-
 	c := &Component{errorChan: make(chan error)}
 
 	consumer := kafkatest.NewMessageConsumer(false)
@@ -74,7 +71,7 @@ func (c *Component) Reset() {
 	os.Remove(outputFilePath)
 }
 
-func (c *Component) DoGetHealthCheck(cfg *config.Config, buildTime string, gitCommit string, version string) (service.HealthChecker, error) {
+func (c *Component) DoGetHealthCheck(cfg *config.Config, buildTime, gitCommit, version string) (service.HealthChecker, error) {
 	return &mock.HealthCheckerMock{
 		AddCheckFunc: func(name string, checker healthcheck.Checker) error { return nil },
 		StartFunc:    func(ctx context.Context) {},

--- a/features/steps/component.go
+++ b/features/steps/component.go
@@ -21,6 +21,7 @@ import (
 const outputFilePath = "/tmp/dpSearchDataExtractor.txt"
 
 type Component struct {
+	ErrorFeature  componenttest.ErrorFeature
 	inputData     models.ZebedeeData
 	serviceList   *service.ExternalServiceList
 	KafkaConsumer kafka.IConsumerGroup

--- a/features/steps/component.go
+++ b/features/steps/component.go
@@ -21,7 +21,6 @@ import (
 const outputFilePath = "/tmp/dpSearchDataExtractor.txt"
 
 type Component struct {
-	componenttest.ErrorFeature
 	inputData     models.ZebedeeData
 	serviceList   *service.ExternalServiceList
 	KafkaConsumer kafka.IConsumerGroup

--- a/features/steps/steps.go
+++ b/features/steps/steps.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ONSdigital/dp-search-data-extractor/service"
 	"github.com/cucumber/godog"
 	"github.com/rdumont/assistdog"
+	"github.com/stretchr/testify/assert"
 )
 
 func (c *Component) RegisterSteps(ctx *godog.ScenarioContext) {
@@ -80,15 +81,9 @@ func (c *Component) iShouldReceivePublishedData() error {
 
 	schema.SearchDataImportEvent.Unmarshal(outputData, data)
 
-	if data.CDID != c.inputData.Description.CDID {
-		return fmt.Errorf("Expected CDID: %v Recevived CDID: %v", c.inputData.Description.CDID, data.CDID)
-	}
-
-	if data.DatasetID != c.inputData.Description.DatasetID {
-		return fmt.Errorf("Expected DatasetID: %v Recevived DatasetID: %v", c.inputData.Description.DatasetID, data.DatasetID)
-	}
-
-	return nil
+	assert.Equal(&c.ErrorFeature, c.inputData.Description.CDID, data.CDID)
+	assert.Equal(&c.ErrorFeature, c.inputData.Description.DatasetID, data.DatasetID)
+	return c.ErrorFeature.StepError()
 }
 
 func (c *Component) convertToKafkaEvents(table *godog.Table) ([]*models.ContentPublished, error) {

--- a/features/steps/steps.go
+++ b/features/steps/steps.go
@@ -26,7 +26,6 @@ func (c *Component) RegisterSteps(ctx *godog.ScenarioContext) {
 }
 
 func (c *Component) sendKafkafkaEvent(table *godog.Table) error {
-
 	observationEvents, err := c.convertToKafkaEvents(table)
 	if err != nil {
 		return err
@@ -79,8 +78,7 @@ func (c *Component) iShouldReceivePublishedData() error {
 
 	var data = &models.SearchDataImport{}
 
-	schema.SearchDataImportEvent.Unmarshal(outputData, data)
-
+	_ = schema.SearchDataImportEvent.Unmarshal(outputData, data)
 	assert.Equal(&c.ErrorFeature, c.inputData.Description.CDID, data.CDID)
 	assert.Equal(&c.ErrorFeature, c.inputData.Description.DatasetID, data.DatasetID)
 	return c.ErrorFeature.StepError()
@@ -103,7 +101,6 @@ func (c *Component) sendToConsumer(e *models.ContentPublished) error {
 
 	c.KafkaConsumer.Channels().Upstream <- kafkatest.NewMessage(bytes, 0)
 	return nil
-
 }
 
 func registerInterrupt() chan os.Signal {

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"context"
 	"encoding/json"
+
 	"github.com/ONSdigital/dp-net/request"
 	"github.com/ONSdigital/dp-search-data-extractor/clients"
 	"github.com/ONSdigital/dp-search-data-extractor/event"
@@ -17,16 +18,16 @@ type ContentPublishedHandler struct {
 }
 
 // Handle takes a single event.
-func (h *ContentPublishedHandler) Handle(ctx context.Context, event *models.ContentPublished, keywordsLimit int) (err error) {
+func (h *ContentPublishedHandler) Handle(ctx context.Context, cpEvent *models.ContentPublished, keywordsLimit int) (err error) {
 
 	traceID := request.NewRequestID(16)
 
 	logData := log.Data{
-		"event": event,
+		"event": cpEvent,
 	}
 	log.Info(ctx, "event handler called", logData)
 
-	contentPublished, err := h.ZebedeeCli.GetPublishedData(ctx, event.URI)
+	contentPublished, err := h.ZebedeeCli.GetPublishedData(ctx, cpEvent.URI)
 	if err != nil {
 		return err
 	}

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -19,7 +19,6 @@ type ContentPublishedHandler struct {
 
 // Handle takes a single event.
 func (h *ContentPublishedHandler) Handle(ctx context.Context, cpEvent *models.ContentPublished, keywordsLimit int) (err error) {
-
 	traceID := request.NewRequestID(16)
 
 	logData := log.Data{
@@ -37,7 +36,7 @@ func (h *ContentPublishedHandler) Handle(ctx context.Context, cpEvent *models.Co
 	}
 	log.Info(ctx, "zebedee response ", logData)
 
-	//byte slice to Json & unMarshall Json
+	// byte slice to Json & unMarshall Json
 	var zebedeeData models.ZebedeeData
 	err = json.Unmarshal(contentPublished, &zebedeeData)
 	if err != nil {
@@ -45,19 +44,19 @@ func (h *ContentPublishedHandler) Handle(ctx context.Context, cpEvent *models.Co
 		return err
 	}
 
-	//keywords validation
+	// keywords validation
 	logData = log.Data{
 		"keywords":      zebedeeData.Description.Keywords,
 		"keywordsLimit": keywordsLimit,
 	}
 
-	//Mapping Json to Avro
+	// Mapping Json to Avro
 	searchData := models.MapZebedeeDataToSearchDataImport(zebedeeData, keywordsLimit)
 	searchData.TraceID = traceID
 	searchData.JobID = ""
 	searchData.SearchIndex = "ONS"
 
-	//Marshall Avro and sending message
+	// Marshall Avro and sending message
 	if err := h.Producer.SearchDataImport(ctx, searchData); err != nil {
 		log.Fatal(ctx, "error while attempting to send SearchDataImport event to producer", err)
 		return err

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -46,7 +46,6 @@ var (
 )
 
 func TestHandlerForZebedeeReturningMandatoryFields(t *testing.T) {
-
 	expectedSearchDataImportEvent := models.SearchDataImport{
 		DataType:        "testDataType",
 		JobID:           "",
@@ -64,7 +63,7 @@ func TestHandlerForZebedeeReturningMandatoryFields(t *testing.T) {
 		ChannelsFunc: getChannelFunc,
 	}
 
-	//for mock marshaller
+	// for mock marshaller
 	expectedSearchDataImport := marshalSearchDataImport(t, expectedSearchDataImportEvent)
 	marshallerMock := &mock.MarshallerMock{
 		MarshalFunc: func(s interface{}) ([]byte, error) {
@@ -136,7 +135,6 @@ func TestHandlerForZebedeeReturningMandatoryFields(t *testing.T) {
 }
 
 func TestHandlerForZebedeeReturningAllFields(t *testing.T) {
-
 	expectedFullSearchDataImportEvent := models.SearchDataImport{
 		DataType:        "testDataType",
 		JobID:           "",
@@ -166,8 +164,7 @@ func TestHandlerForZebedeeReturningAllFields(t *testing.T) {
 	}
 
 	Convey("Given an event handler working successfully, and an event containing a URI", t, func() {
-
-		//used by zebedee mock
+		// used by zebedee mock
 		fullContentPublishedTestData := `{"description":{"cdid": "testCDID","datasetId": "testDaetasetId","edition": "testedition","keywords": ["testkeyword"],"metaDescription": "testMetaDescription","releaseDate": "testReleaseDate","summary": "testSummary","title": "testTitle"},"type": "testDataType"}`
 		getFullPublishDataFunc := func(ctx context.Context, uriString string) ([]byte, error) {
 			data := []byte(fullContentPublishedTestData)
@@ -178,7 +175,6 @@ func TestHandlerForZebedeeReturningAllFields(t *testing.T) {
 		eventHandler := &handler.ContentPublishedHandler{zebedeeMock, *producerMock}
 
 		Convey("When given a valid event with default keywords limit", func() {
-
 			err := eventHandler.Handle(context.Background(), &testEvent, -1)
 
 			var avroBytes []byte
@@ -219,8 +215,8 @@ func TestHandlerForZebedeeReturningAllFields(t *testing.T) {
 }
 
 // marshalSearchDataImport helper method to marshal a event into a []byte
-func marshalSearchDataImport(t *testing.T, event models.SearchDataImport) []byte {
-	bytes, err := schema.SearchDataImportEvent.Marshal(event)
+func marshalSearchDataImport(t *testing.T, sdEvent models.SearchDataImport) []byte {
+	bytes, err := schema.SearchDataImportEvent.Marshal(sdEvent)
 	if err != nil {
 		t.Fatalf("avro mashalling failed with error : %v", err)
 	}

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"os/signal"
+	"syscall"
 
 	"github.com/ONSdigital/dp-search-data-extractor/service"
 	"github.com/ONSdigital/log.go/v2/log"
@@ -33,7 +34,7 @@ func main() {
 
 func run(ctx context.Context) error {
 	signals := make(chan os.Signal, 1)
-	signal.Notify(signals, os.Interrupt, os.Kill)
+	signal.Notify(signals, os.Interrupt, syscall.SIGTERM)
 
 	// Run the service, providing an error channel for fatal errors
 	svcErrors := make(chan error, 1)

--- a/main_test.go
+++ b/main_test.go
@@ -16,7 +16,6 @@ type ComponentTest struct {
 }
 
 func (f *ComponentTest) InitializeScenario(ctx *godog.ScenarioContext) {
-
 	testComponent := steps.NewComponent()
 
 	ctx.BeforeScenario(func(*godog.Scenario) {

--- a/models/mapper.go
+++ b/models/mapper.go
@@ -23,7 +23,6 @@ func MapZebedeeDataToSearchDataImport(zebedeeData ZebedeeData, keywordsLimit int
 // any whitespace. It also optionally takes a limit which truncates the keywords to the desired amount. This value can
 // be -1 for no truncation.
 func RectifyKeywords(keywords []string, keywordsLimit int) []string {
-
 	var strArray []string
 	rectifiedKeywords := make([]string, 0)
 

--- a/models/mapper_test.go
+++ b/models/mapper_test.go
@@ -1,9 +1,10 @@
 package models_test
 
 import (
+	"testing"
+
 	"github.com/ONSdigital/dp-search-data-extractor/models"
 	. "github.com/smartystreets/goconvey/convey"
-	"testing"
 )
 
 const (

--- a/models/mapper_test.go
+++ b/models/mapper_test.go
@@ -83,7 +83,6 @@ func TestMapZebedeeDataToSearchDataImport(t *testing.T) {
 }
 
 func TestRectifyKeywords_WithEmptyKeywordsAndDefaultLimit(t *testing.T) {
-
 	Convey("Given an empty keywords as received from zebedee  with default keywords limit", t, func() {
 		testKeywords := []string{""}
 
@@ -98,7 +97,6 @@ func TestRectifyKeywords_WithEmptyKeywordsAndDefaultLimit(t *testing.T) {
 }
 
 func TestRectifyKeywords_WithTrimmingKeywordsAndDefaultLimit(t *testing.T) {
-
 	Convey("Given un-trimmed keywords as received from zebedee  with default keywords limit", t, func() {
 		testKeywords := []string{"  testKeywords1,testKeywords2   "}
 
@@ -114,13 +112,10 @@ func TestRectifyKeywords_WithTrimmingKeywordsAndDefaultLimit(t *testing.T) {
 }
 
 func TestRectifyKeywords_LessFourKeywordsAndDefaultLimit(t *testing.T) {
-
 	Convey("Given a keywords as received from zebedee with default keywords limit", t, func() {
 		testKeywords := []string{"testkeyword1,testkeyword2", "testkeyword3,testKeywords4"}
-
 		Convey("When passed to rectify the keywords with default keywords limit", func() {
 			actual := models.RectifyKeywords(testKeywords, -1)
-
 			Convey("Then all the same keywords should be returned", func() {
 				expectedKeywords := []string{"testkeyword1", "testkeyword2", "testkeyword3", "testKeywords4"}
 				So(actual, ShouldResemble, expectedKeywords)
@@ -130,13 +125,10 @@ func TestRectifyKeywords_LessFourKeywordsAndDefaultLimit(t *testing.T) {
 }
 
 func TestRectifyKeywords_WithEightKeywordsAndZeroAsLimit(t *testing.T) {
-
 	Convey("Given a keywords as received from zebedee with zero keywords limit", t, func() {
 		testKeywords := []string{"testkeyword1,testkeyword2", "testkeyword3,testKeywords4", "testkeyword5,testKeywords6,testkeyword7,testKeywords8"}
-
 		Convey("When passed to rectify the keywords with default keywords limits", func() {
 			actual := models.RectifyKeywords(testKeywords, 0)
-
 			Convey("Then keywords should be rectified with empty keyword elements", func() {
 				expectedKeywords := []string{""}
 				So(actual, ShouldResemble, expectedKeywords)
@@ -146,13 +138,10 @@ func TestRectifyKeywords_WithEightKeywordsAndZeroAsLimit(t *testing.T) {
 }
 
 func TestRectifyKeywords_WithEightKeywordsAndDefaultLimit(t *testing.T) {
-
 	Convey("Given a keywords as received from zebedee with default keywords limit", t, func() {
 		testKeywords := []string{"testkeyword1,testkeyword2", "testkeyword3,testKeywords4", "testkeyword5,testKeywords6,testkeyword7,testKeywords8"}
-
 		Convey("When passed to rectify the keywords with default keywords limits", func() {
 			actual := models.RectifyKeywords(testKeywords, -1)
-
 			Convey("Then keywords should be rectified with correct size with all keyword elements", func() {
 				expectedKeywords := []string{"testkeyword1", "testkeyword2", "testkeyword3", "testKeywords4", "testkeyword5", "testKeywords6", "testkeyword7", "testKeywords8"}
 				So(actual, ShouldResemble, expectedKeywords)
@@ -162,13 +151,10 @@ func TestRectifyKeywords_WithEightKeywordsAndDefaultLimit(t *testing.T) {
 }
 
 func TestRectifyKeywords_EightKeywordsAndFiveAsLimit(t *testing.T) {
-
 	Convey("Given a keywords as received from zebedee with five keywords limit", t, func() {
 		testKeywords := []string{"testkeyword1,testkeyword2", "testkeyword3,testKeywords4", "testkeyword5,testKeywords6,testkeyword7,testKeywords8"}
-
 		Convey("When passed to rectify the keywords with keywords limit as 5", func() {
 			actual := models.RectifyKeywords(testKeywords, 5)
-
 			Convey("Then keywords should be rectified with correct size with expected elements", func() {
 				expectedKeywords := []string{"testkeyword1", "testkeyword2", "testkeyword3", "testKeywords4", "testkeyword5"}
 				So(actual, ShouldResemble, expectedKeywords)
@@ -178,13 +164,10 @@ func TestRectifyKeywords_EightKeywordsAndFiveAsLimit(t *testing.T) {
 }
 
 func TestRectifyKeywords_EightKeywordsAndTenAsLimit(t *testing.T) {
-
 	Convey("Given a keywords as received from zebedee with ten keywords limit", t, func() {
 		testKeywords := []string{"testkeyword1,testkeyword2", "testkeyword3,testKeywords4", "testkeyword5,testKeywords6,testkeyword7,testKeywords8"}
-
 		Convey("When passed to rectify the keywords with keywords limit as 5", func() {
 			actual := models.RectifyKeywords(testKeywords, 10)
-
 			Convey("Then keywords should be rectified with correct size with expected elements", func() {
 				expectedKeywords := []string{"testkeyword1", "testkeyword2", "testkeyword3", "testKeywords4", "testkeyword5", "testKeywords6", "testkeyword7", "testKeywords8"}
 				So(actual, ShouldResemble, expectedKeywords)

--- a/service/service.go
+++ b/service/service.go
@@ -170,7 +170,6 @@ func (svc *Service) Close(ctx context.Context) error {
 }
 
 func registerCheckers(ctx context.Context, hc HealthChecker, zebedeeClient clients.ZebedeeClient, consumer kafka.IConsumerGroup, producer kafka.IProducer) (err error) {
-
 	hasErrors := false
 
 	if err := hc.AddCheck("Zebedee client", zebedeeClient.Checker); err != nil {

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -201,7 +201,6 @@ func TestRun(t *testing.T) {
 
 func TestClose(t *testing.T) {
 	Convey("Having a correctly initialised service", t, func() {
-
 		hcStopped := false
 
 		zebedeeMock := &clientMock.ZebedeeClientMock{


### PR DESCRIPTION
### What

- This adds the golangci linter to the dp-search-reindex-api repo. This PR enables the following linters via .golangci.yml
`
    - deadcode
    - depguard
    - dogsled
    - errcheck
    - gochecknoinits
    - goconst
    - gocritic
    - gocyclo
    - gofmt
    - goimports
    - revive
    - gosec
    - gosimple
    - govet
    - ineffassign
    - nakedret
    - staticcheck
    - structcheck
    - stylecheck
    - typecheck
    - unconvert
    - unused
    - varcheck
    - whitespace
    - gocognit
    - prealloc`

This PR also attempts to fix the existing lint issues with the repo. **Please Note** in .golangci.yaml linter configuration file there is an parameter under issues attribute reffered to as `new` I have set it to false (default), but when you set it to true then it will ignore all the existing lint issues and will flag only the new lint issues. 

### How to review

Please have a look into the .golangcilint.yml file and see if the linters listed here make sense , also if you would like to add any additional linters we can always do that . For the first pass I think we have enough linters enabled (mentioned above). 
