### PR TITLE
Add linter and fix lint issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,93 @@
+# This file was inspired by the golangci-lint one:
+# https://github.com/golangci/golangci-lint/blob/master/.golangci.yml
+run:
+  # default concurrency is a available CPU number
+  concurrency: 4
+
+  # timeout for analysis, e.g. 30s, 5m, default is 1m
+  timeout: 5m
+linters-settings:
+  govet:
+    check-shadowing: true
+  golint:
+    min-confidence: 0
+  gocyclo:
+    min-complexity: 15
+  maligned:
+    suggest-new: true
+  dupl:
+    threshold: 100
+  goconst:
+    min-len: 2
+    min-occurrences: 2
+  misspell:
+    locale: UK
+  lll:
+    line-length: 140
+  gofmt:
+    simplify: false
+  gocritic:
+    enabled-tags:
+      - diagnostic
+      - experimental
+      - opinionated
+      - performance
+      - style
+    disabled-checks:
+      - wrapperFunc
+      - dupImport # https://github.com/go-critic/go-critic/issues/845
+      - ifElseChain
+      - octalLiteral
+      - hugeParam
+  funlen:
+  # lines: 100
+  # statements: 100
+
+linters:
+  # please, do not use `enable-all`: it's deprecated and will be removed soon.
+  # inverted configuration with `enable-all` and `disable` is not scalable during updates of golangci-lint
+  disable-all: true
+  enable:
+    - deadcode
+    - depguard
+    - dogsled
+    - errcheck
+    - gochecknoinits
+    - goconst
+    - gocritic
+    - gocyclo
+    - gofmt
+    - goimports
+    - revive
+    - gosec
+    - gosimple
+    - govet
+    - ineffassign
+    - nakedret
+    - staticcheck
+    - structcheck
+    - stylecheck
+    - typecheck
+    - unconvert
+    - unused
+    - varcheck
+    - whitespace
+    - gocognit
+    - prealloc
+
+issues:
+  exclude-rules:
+    - path: _test\.go
+      linters:
+        - gocyclo
+        - errcheck
+        - dupl
+        - gosec
+  new: false
+
+# golangci.com configuration
+# https://github.com/golangci/golangci/wiki/Configuration
+service:
+  golangci-lint-version: 1.43.x # use the fixed version to not introduce new linters unexpectedly
+  prepare:
+    - echo "here I can run custom commands, but no preparation needed for this repo"

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,8 @@ audit:
 	go list -m all | nancy sleuth
 .PHONY: lint
 lint:
-	exit
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.43.0
+	golangci-lint run ./...
 
 .PHONY: build
 build: fmt

--- a/ci/lint.yml
+++ b/ci/lint.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: latest
+    tag: 1.17.1
 
 inputs:
   - name: dp-search-data-extractor

--- a/cmd/producer/main.go
+++ b/cmd/producer/main.go
@@ -53,7 +53,10 @@ func main() {
 		}
 
 		// Send bytes to Output channel, after calling Initialise just in case it is not initialised.
-		kafkaProducer.Initialise(ctx)
+		if err := kafkaProducer.Initialise(ctx); err != nil {
+			log.Warn(ctx, "failed to initialise kafka producer")
+			return
+		}
 		kafkaProducer.Channels().Output <- bytes
 	}
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -12,13 +12,10 @@ func TestConfig(t *testing.T) {
 	Convey("Given an environment with no environment variables set", t, func() {
 		os.Clearenv()
 		cfg, err := Get()
-
 		Convey("When the config values are retrieved", func() {
-
 			Convey("Then there should be no error returned", func() {
 				So(err, ShouldBeNil)
 			})
-
 			Convey("Then the values should be set to the expected defaults", func() {
 				So(cfg.BindAddr, ShouldEqual, "localhost:25800")
 				So(cfg.GracefulShutdownTimeout, ShouldEqual, 5*time.Second)
@@ -37,7 +34,6 @@ func TestConfig(t *testing.T) {
 				So(cfg.KafkaProducerTopic, ShouldEqual, "search-data-import")
 				So(cfg.ZebedeeURL, ShouldEqual, "http://localhost:8082")
 			})
-
 			Convey("Then a second call to config should return the same config", func() {
 				newCfg, newErr := Get()
 				So(newErr, ShouldBeNil)

--- a/event/consumer.go
+++ b/event/consumer.go
@@ -19,7 +19,6 @@ type Handler interface {
 
 // Consume converts messages to event instances, and pass the event to the provided handler.
 func Consume(ctx context.Context, messageConsumer kafka.IConsumerGroup, handler Handler, cfg *config.Config) {
-
 	// consume loop, to be executed by each worker
 	var consume = func(workerID int) {
 		for {
@@ -48,7 +47,6 @@ func Consume(ctx context.Context, messageConsumer kafka.IConsumerGroup, handler 
 // processMessage unmarshals the provided kafka message into an event and calls the handler.
 // After the message is handled, it is committed.
 func processMessage(ctx context.Context, message kafka.Message, handler Handler, cfg *config.Config) {
-
 	// unmarshal - commit on failure (consuming the message again would result in the same error)
 	event, err := unmarshal(message)
 	if err != nil {

--- a/event/consumer_test.go
+++ b/event/consumer_test.go
@@ -27,9 +27,7 @@ var testEvent = models.ContentPublished{
 }
 
 func TestConsume(t *testing.T) {
-
 	Convey("Given kafka consumer and event handler mocks", t, func() {
-
 		cgChannels := &kafka.ConsumerGroupChannels{Upstream: make(chan kafka.Message, 2)}
 		mockConsumer := &kafkatest.IConsumerGroupMock{
 			ChannelsFunc: func() *kafka.ConsumerGroupChannels { return cgChannels },
@@ -42,23 +40,17 @@ func TestConsume(t *testing.T) {
 				return nil
 			},
 		}
-
 		Convey("And a kafka message with the valid schema being sent to the Upstream channel", func() {
-
 			message := kafkatest.NewMessage(marshal(testEvent), 0)
 			mockConsumer.Channels().Upstream <- message
-
 			Convey("When consume message is called", func() {
-
 				handlerWg.Add(1)
 				event.Consume(testCtx, mockConsumer, mockEventHandler, &config.Config{KafkaNumWorkers: 1})
 				handlerWg.Wait()
-
 				Convey("An event is sent to the mockEventHandler ", func() {
 					So(len(mockEventHandler.HandleCalls()), ShouldEqual, 1)
 					So(*mockEventHandler.HandleCalls()[0].ContentPublished, ShouldResemble, testEvent)
 				})
-
 				Convey("The message is committed and the consumer is released", func() {
 					<-message.UpstreamDone()
 					So(len(message.CommitCalls()), ShouldEqual, 1)
@@ -66,25 +58,19 @@ func TestConsume(t *testing.T) {
 				})
 			})
 		})
-
 		Convey("And two kafka messages, one with a valid schema and one with an invalid schema", func() {
-
 			validMessage := kafkatest.NewMessage(marshal(testEvent), 1)
 			invalidMessage := kafkatest.NewMessage([]byte("invalid schema"), 0)
 			mockConsumer.Channels().Upstream <- invalidMessage
 			mockConsumer.Channels().Upstream <- validMessage
-
 			Convey("When consume messages is called", func() {
-
 				handlerWg.Add(1)
 				event.Consume(testCtx, mockConsumer, mockEventHandler, &config.Config{KafkaNumWorkers: 1})
 				handlerWg.Wait()
-
 				Convey("Only the valid event is sent to the mockEventHandler ", func() {
 					So(len(mockEventHandler.HandleCalls()), ShouldEqual, 1)
 					So(*mockEventHandler.HandleCalls()[0].ContentPublished, ShouldResemble, testEvent)
 				})
-
 				Convey("Only the valid message is committed, but the consumer is released for both messages", func() {
 					<-validMessage.UpstreamDone()
 					<-invalidMessage.UpstreamDone()
@@ -95,7 +81,6 @@ func TestConsume(t *testing.T) {
 				})
 			})
 		})
-
 		Convey("With a failing handler and a kafka message with the valid schema being sent to the Upstream channel", func() {
 			mockEventHandler.HandleFunc = func(ctx context.Context, event *models.ContentPublished, keywordsLimit int) error {
 				defer handlerWg.Done()
@@ -103,18 +88,14 @@ func TestConsume(t *testing.T) {
 			}
 			message := kafkatest.NewMessage(marshal(testEvent), 0)
 			mockConsumer.Channels().Upstream <- message
-
 			Convey("When consume message is called", func() {
-
 				handlerWg.Add(1)
 				event.Consume(testCtx, mockConsumer, mockEventHandler, &config.Config{KafkaNumWorkers: 1})
 				handlerWg.Wait()
-
 				Convey("An event is sent to the mockEventHandler ", func() {
 					So(len(mockEventHandler.HandleCalls()), ShouldEqual, 1)
 					So(*mockEventHandler.HandleCalls()[0].ContentPublished, ShouldResemble, testEvent)
 				})
-
 				Convey("The message is committed and the consumer is released", func() {
 					<-message.UpstreamDone()
 					So(len(message.CommitCalls()), ShouldEqual, 1)
@@ -126,8 +107,8 @@ func TestConsume(t *testing.T) {
 }
 
 // marshal helper method to marshal a event into a []byte
-func marshal(event models.ContentPublished) []byte {
-	bytes, err := schema.ContentPublishedEvent.Marshal(event)
+func marshal(cpEvent models.ContentPublished) []byte {
+	bytes, err := schema.ContentPublishedEvent.Marshal(cpEvent)
 	So(err, ShouldBeNil)
 	return bytes
 }

--- a/event/producer_test.go
+++ b/event/producer_test.go
@@ -35,7 +35,6 @@ var (
 
 func TestProducer_SearchDataImport(t *testing.T) {
 	Convey("Given SearchDataImportProducer has been configured correctly", t, func() {
-
 		pChannels := &kafka.ProducerChannels{
 			Output: make(chan []byte, 1),
 		}
@@ -52,13 +51,12 @@ func TestProducer_SearchDataImport(t *testing.T) {
 			},
 		}
 
-		//event is message
+		// event is message
 		searchDataImportProducer := event.SearchDataImportProducer{
 			Producer:   kafkaProducerMock,
 			Marshaller: marshallerMock,
 		}
 		Convey("When SearchDataImport is called on the event producer", func() {
-
 			err := searchDataImportProducer.SearchDataImport(ctx, expectedSearchDataImportEvent)
 			So(err, ShouldBeNil)
 
@@ -84,7 +82,6 @@ func TestProducer_SearchDataImport(t *testing.T) {
 
 func TestProducer_SearchDataImport_MarshalErr(t *testing.T) {
 	Convey("Given InstanceCompletedProducer has been configured correctly", t, func() {
-
 		pChannels := &kafka.ProducerChannels{
 			Output: make(chan []byte, 1),
 		}
@@ -101,7 +98,7 @@ func TestProducer_SearchDataImport_MarshalErr(t *testing.T) {
 			},
 		}
 
-		//event is message
+		// event is message
 		searchDataImportProducer := event.SearchDataImportProducer{
 			Producer:   kafkaProducerMock,
 			Marshaller: marshallerMock,

--- a/features/steps/component.go
+++ b/features/steps/component.go
@@ -2,6 +2,8 @@ package steps
 
 import (
 	"context"
+	"net/http"
+
 	componenttest "github.com/ONSdigital/dp-component-test"
 	"github.com/ONSdigital/dp-healthcheck/healthcheck"
 	kafka "github.com/ONSdigital/dp-kafka/v2"
@@ -12,7 +14,6 @@ import (
 	"github.com/ONSdigital/dp-search-data-extractor/models"
 	"github.com/ONSdigital/dp-search-data-extractor/service"
 	"github.com/ONSdigital/dp-search-data-extractor/service/mock"
-	"net/http"
 )
 
 type Component struct {

--- a/features/steps/component.go
+++ b/features/steps/component.go
@@ -2,9 +2,6 @@ package steps
 
 import (
 	"context"
-	"net/http"
-	"os"
-
 	componenttest "github.com/ONSdigital/dp-component-test"
 	"github.com/ONSdigital/dp-healthcheck/healthcheck"
 	kafka "github.com/ONSdigital/dp-kafka/v2"
@@ -15,10 +12,8 @@ import (
 	"github.com/ONSdigital/dp-search-data-extractor/models"
 	"github.com/ONSdigital/dp-search-data-extractor/service"
 	"github.com/ONSdigital/dp-search-data-extractor/service/mock"
+	"net/http"
 )
-
-// outputFilePath is used for event received by the service.
-const outputFilePath = "/tmp/dpSearchDataExtractor.txt"
 
 type Component struct {
 	ErrorFeature  componenttest.ErrorFeature
@@ -27,15 +22,12 @@ type Component struct {
 	KafkaConsumer kafka.IConsumerGroup
 	KafkaProducer kafka.IProducer
 	zebedeeClient clients.ZebedeeClient
-	killChannel   chan os.Signal
-	apiFeature    *componenttest.APIFeature
 	errorChan     chan error
 	svc           *service.Service
 	cfg           *config.Config
 }
 
 func NewComponent() *Component {
-
 	c := &Component{errorChan: make(chan error)}
 
 	consumer := kafkatest.NewMessageConsumer(false)
@@ -66,15 +58,7 @@ func NewComponent() *Component {
 	return c
 }
 
-func (c *Component) Close() {
-	os.Remove(outputFilePath)
-}
-
-func (c *Component) Reset() {
-	os.Remove(outputFilePath)
-}
-
-func (c *Component) DoGetHealthCheck(cfg *config.Config, buildTime string, gitCommit string, version string) (service.HealthChecker, error) {
+func (c *Component) DoGetHealthCheck(cfg *config.Config, buildTime, gitCommit, version string) (service.HealthChecker, error) {
 	return &mock.HealthCheckerMock{
 		AddCheckFunc: func(name string, checker healthcheck.Checker) error { return nil },
 		StartFunc:    func(ctx context.Context) {},

--- a/features/steps/steps.go
+++ b/features/steps/steps.go
@@ -26,7 +26,6 @@ func (c *Component) RegisterSteps(ctx *godog.ScenarioContext) {
 }
 
 func (c *Component) sendKafkafkaEvent(table *godog.Table) error {
-
 	observationEvents, err := c.convertToKafkaEvents(table)
 	if err != nil {
 		return err
@@ -79,7 +78,7 @@ func (c *Component) iShouldReceivePublishedData() error {
 
 	var data = &models.SearchDataImport{}
 
-	schema.SearchDataImportEvent.Unmarshal(outputData, data)
+	_ = schema.SearchDataImportEvent.Unmarshal(outputData, data)
 
 	assert.Equal(&c.ErrorFeature, c.inputData.Description.CDID, data.CDID)
 	assert.Equal(&c.ErrorFeature, c.inputData.Description.DatasetID, data.DatasetID)
@@ -103,7 +102,6 @@ func (c *Component) sendToConsumer(e *models.ContentPublished) error {
 
 	c.KafkaConsumer.Channels().Upstream <- kafkatest.NewMessage(bytes, 0)
 	return nil
-
 }
 
 func registerInterrupt() chan os.Signal {

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -46,7 +46,6 @@ var (
 )
 
 func TestHandlerForZebedeeReturningMandatoryFields(t *testing.T) {
-
 	expectedSearchDataImportEvent := models.SearchDataImport{
 		DataType:        "testDataType",
 		JobID:           "",
@@ -64,7 +63,7 @@ func TestHandlerForZebedeeReturningMandatoryFields(t *testing.T) {
 		ChannelsFunc: getChannelFunc,
 	}
 
-	//for mock marshaller
+	// for mock marshaller
 	expectedSearchDataImport := marshalSearchDataImport(t, expectedSearchDataImportEvent)
 	marshallerMock := &mock.MarshallerMock{
 		MarshalFunc: func(s interface{}) ([]byte, error) {
@@ -76,11 +75,9 @@ func TestHandlerForZebedeeReturningMandatoryFields(t *testing.T) {
 		Producer:   kafkaProducerMock,
 		Marshaller: marshallerMock,
 	}
-
 	Convey("Given an event handler working successfully, and an event containing a URI", t, func() {
 		var zebedeeMock = &clientMock.ZebedeeClientMock{GetPublishedDataFunc: getPublishDataFunc}
 		eventHandler := &handler.ContentPublishedHandler{zebedeeMock, *producerMock}
-
 		Convey("When given a valid event", func() {
 			err := eventHandler.Handle(context.Background(), &testEvent, -1)
 
@@ -91,7 +88,6 @@ func TestHandlerForZebedeeReturningMandatoryFields(t *testing.T) {
 			case <-time.After(testTimeout):
 				t.FailNow()
 			}
-
 			Convey("Then no error is reported", func() {
 				So(err, ShouldBeNil)
 			})
@@ -136,7 +132,6 @@ func TestHandlerForZebedeeReturningMandatoryFields(t *testing.T) {
 }
 
 func TestHandlerForZebedeeReturningAllFields(t *testing.T) {
-
 	expectedFullSearchDataImportEvent := models.SearchDataImport{
 		DataType:        "testDataType",
 		JobID:           "",
@@ -164,10 +159,8 @@ func TestHandlerForZebedeeReturningAllFields(t *testing.T) {
 		Producer:   kafkaProducerMock,
 		Marshaller: marshallerMock,
 	}
-
 	Convey("Given an event handler working successfully, and an event containing a URI", t, func() {
-
-		//used by zebedee mock
+		// used by zebedee mock
 		fullContentPublishedTestData := `{"description":{"cdid": "testCDID","datasetId": "testDaetasetId","edition": "testedition","keywords": ["testkeyword"],"metaDescription": "testMetaDescription","releaseDate": "testReleaseDate","summary": "testSummary","title": "testTitle"},"type": "testDataType"}`
 		getFullPublishDataFunc := func(ctx context.Context, uriString string) ([]byte, error) {
 			data := []byte(fullContentPublishedTestData)
@@ -176,9 +169,7 @@ func TestHandlerForZebedeeReturningAllFields(t *testing.T) {
 
 		var zebedeeMock = &clientMock.ZebedeeClientMock{GetPublishedDataFunc: getFullPublishDataFunc}
 		eventHandler := &handler.ContentPublishedHandler{zebedeeMock, *producerMock}
-
 		Convey("When given a valid event with default keywords limit", func() {
-
 			err := eventHandler.Handle(context.Background(), &testEvent, -1)
 
 			var avroBytes []byte
@@ -188,7 +179,6 @@ func TestHandlerForZebedeeReturningAllFields(t *testing.T) {
 			case <-time.After(testTimeout):
 				t.FailNow()
 			}
-
 			Convey("Then no error is reported", func() {
 				So(err, ShouldBeNil)
 			})
@@ -219,8 +209,8 @@ func TestHandlerForZebedeeReturningAllFields(t *testing.T) {
 }
 
 // marshalSearchDataImport helper method to marshal a event into a []byte
-func marshalSearchDataImport(t *testing.T, event models.SearchDataImport) []byte {
-	bytes, err := schema.SearchDataImportEvent.Marshal(event)
+func marshalSearchDataImport(t *testing.T, sdEvent models.SearchDataImport) []byte {
+	bytes, err := schema.SearchDataImportEvent.Marshal(sdEvent)
 	if err != nil {
 		t.Fatalf("avro mashalling failed with error : %v", err)
 	}

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"os/signal"
+	"syscall"
 
 	"github.com/ONSdigital/dp-search-data-extractor/service"
 	"github.com/ONSdigital/log.go/v2/log"
@@ -33,7 +34,7 @@ func main() {
 
 func run(ctx context.Context) error {
 	signals := make(chan os.Signal, 1)
-	signal.Notify(signals, os.Interrupt, os.Kill)
+	signal.Notify(signals, os.Interrupt, syscall.SIGTERM)
 
 	// Run the service, providing an error channel for fatal errors
 	svcErrors := make(chan error, 1)

--- a/main_test.go
+++ b/main_test.go
@@ -16,17 +16,7 @@ type ComponentTest struct {
 }
 
 func (f *ComponentTest) InitializeScenario(ctx *godog.ScenarioContext) {
-
 	testComponent := steps.NewComponent()
-
-	ctx.BeforeScenario(func(*godog.Scenario) {
-		testComponent.Reset()
-	})
-
-	ctx.AfterScenario(func(*godog.Scenario, error) {
-		testComponent.Close()
-	})
-
 	testComponent.RegisterSteps(ctx)
 }
 

--- a/models/mapper.go
+++ b/models/mapper.go
@@ -23,7 +23,6 @@ func MapZebedeeDataToSearchDataImport(zebedeeData ZebedeeData, keywordsLimit int
 // any whitespace. It also optionally takes a limit which truncates the keywords to the desired amount. This value can
 // be -1 for no truncation.
 func RectifyKeywords(keywords []string, keywordsLimit int) []string {
-
 	var strArray []string
 	rectifiedKeywords := make([]string, 0)
 

--- a/models/mapper_test.go
+++ b/models/mapper_test.go
@@ -1,9 +1,10 @@
 package models_test
 
 import (
+	"testing"
+
 	"github.com/ONSdigital/dp-search-data-extractor/models"
 	. "github.com/smartystreets/goconvey/convey"
-	"testing"
 )
 
 const (
@@ -38,10 +39,8 @@ func TestMapZebedeeDataToSearchDataImport(t *testing.T) {
 				Title:           someTitle,
 			},
 		}
-
 		Convey("When mapped with a default keywords limit", func() {
 			result := models.MapZebedeeDataToSearchDataImport(zebendeeData, -1)
-
 			Convey("Then the result should be validly mapped with 4 keywords", func() {
 				So(result.DataType, ShouldResemble, someDataType)
 				So(result.CDID, ShouldResemble, someCDID)
@@ -59,10 +58,8 @@ func TestMapZebedeeDataToSearchDataImport(t *testing.T) {
 				So(result.Keywords[3], ShouldResemble, somekeyword3)
 			})
 		})
-
 		Convey("When mapped with a keywords limit of 2", func() {
 			result := models.MapZebedeeDataToSearchDataImport(zebendeeData, 2)
-
 			Convey("Then the result should be validly mapped with 2 keywords", func() {
 				So(result.DataType, ShouldResemble, someDataType)
 				So(result.CDID, ShouldResemble, someCDID)
@@ -82,13 +79,10 @@ func TestMapZebedeeDataToSearchDataImport(t *testing.T) {
 }
 
 func TestRectifyKeywords_WithEmptyKeywordsAndDefaultLimit(t *testing.T) {
-
 	Convey("Given an empty keywords as received from zebedee  with default keywords limit", t, func() {
 		testKeywords := []string{""}
-
 		Convey("When passed to rectify the keywords with default keywords limit", func() {
 			actual := models.RectifyKeywords(testKeywords, -1)
-
 			Convey("Then keywords should be rectified as expected empty keywords", func() {
 				So(actual, ShouldResemble, testKeywords)
 			})
@@ -97,13 +91,10 @@ func TestRectifyKeywords_WithEmptyKeywordsAndDefaultLimit(t *testing.T) {
 }
 
 func TestRectifyKeywords_WithTrimmingKeywordsAndDefaultLimit(t *testing.T) {
-
 	Convey("Given un-trimmed keywords as received from zebedee  with default keywords limit", t, func() {
 		testKeywords := []string{"  testKeywords1,testKeywords2   "}
-
 		Convey("When passed to rectify keywords with keywords limits as 2", func() {
 			actual := models.RectifyKeywords(testKeywords, -1)
-
 			Convey("Then keywords should be rectified with correct size and expected trimmed elements", func() {
 				expectedKeywords := []string{"testKeywords1", "testKeywords2"}
 				So(actual, ShouldResemble, expectedKeywords)
@@ -113,13 +104,10 @@ func TestRectifyKeywords_WithTrimmingKeywordsAndDefaultLimit(t *testing.T) {
 }
 
 func TestRectifyKeywords_LessFourKeywordsAndDefaultLimit(t *testing.T) {
-
 	Convey("Given a keywords as received from zebedee with default keywords limit", t, func() {
 		testKeywords := []string{"testkeyword1,testkeyword2", "testkeyword3,testKeywords4"}
-
 		Convey("When passed to rectify the keywords with default keywords limit", func() {
 			actual := models.RectifyKeywords(testKeywords, -1)
-
 			Convey("Then all the same keywords should be returned", func() {
 				expectedKeywords := []string{"testkeyword1", "testkeyword2", "testkeyword3", "testKeywords4"}
 				So(actual, ShouldResemble, expectedKeywords)
@@ -129,13 +117,10 @@ func TestRectifyKeywords_LessFourKeywordsAndDefaultLimit(t *testing.T) {
 }
 
 func TestRectifyKeywords_WithEightKeywordsAndZeroAsLimit(t *testing.T) {
-
 	Convey("Given a keywords as received from zebedee with zero keywords limit", t, func() {
 		testKeywords := []string{"testkeyword1,testkeyword2", "testkeyword3,testKeywords4", "testkeyword5,testKeywords6,testkeyword7,testKeywords8"}
-
 		Convey("When passed to rectify the keywords with default keywords limits", func() {
 			actual := models.RectifyKeywords(testKeywords, 0)
-
 			Convey("Then keywords should be rectified with empty keyword elements", func() {
 				expectedKeywords := []string{""}
 				So(actual, ShouldResemble, expectedKeywords)
@@ -145,13 +130,10 @@ func TestRectifyKeywords_WithEightKeywordsAndZeroAsLimit(t *testing.T) {
 }
 
 func TestRectifyKeywords_WithEightKeywordsAndDefaultLimit(t *testing.T) {
-
 	Convey("Given a keywords as received from zebedee with default keywords limit", t, func() {
 		testKeywords := []string{"testkeyword1,testkeyword2", "testkeyword3,testKeywords4", "testkeyword5,testKeywords6,testkeyword7,testKeywords8"}
-
 		Convey("When passed to rectify the keywords with default keywords limits", func() {
 			actual := models.RectifyKeywords(testKeywords, -1)
-
 			Convey("Then keywords should be rectified with correct size with all keyword elements", func() {
 				expectedKeywords := []string{"testkeyword1", "testkeyword2", "testkeyword3", "testKeywords4", "testkeyword5", "testKeywords6", "testkeyword7", "testKeywords8"}
 				So(actual, ShouldResemble, expectedKeywords)
@@ -161,13 +143,10 @@ func TestRectifyKeywords_WithEightKeywordsAndDefaultLimit(t *testing.T) {
 }
 
 func TestRectifyKeywords_EightKeywordsAndFiveAsLimit(t *testing.T) {
-
 	Convey("Given a keywords as received from zebedee with five keywords limit", t, func() {
 		testKeywords := []string{"testkeyword1,testkeyword2", "testkeyword3,testKeywords4", "testkeyword5,testKeywords6,testkeyword7,testKeywords8"}
-
 		Convey("When passed to rectify the keywords with keywords limit as 5", func() {
 			actual := models.RectifyKeywords(testKeywords, 5)
-
 			Convey("Then keywords should be rectified with correct size with expected elements", func() {
 				expectedKeywords := []string{"testkeyword1", "testkeyword2", "testkeyword3", "testKeywords4", "testkeyword5"}
 				So(actual, ShouldResemble, expectedKeywords)
@@ -177,13 +156,10 @@ func TestRectifyKeywords_EightKeywordsAndFiveAsLimit(t *testing.T) {
 }
 
 func TestRectifyKeywords_EightKeywordsAndTenAsLimit(t *testing.T) {
-
 	Convey("Given a keywords as received from zebedee with ten keywords limit", t, func() {
 		testKeywords := []string{"testkeyword1,testkeyword2", "testkeyword3,testKeywords4", "testkeyword5,testKeywords6,testkeyword7,testKeywords8"}
-
 		Convey("When passed to rectify the keywords with keywords limit as 5", func() {
 			actual := models.RectifyKeywords(testKeywords, 10)
-
 			Convey("Then keywords should be rectified with correct size with expected elements", func() {
 				expectedKeywords := []string{"testkeyword1", "testkeyword2", "testkeyword3", "testKeywords4", "testkeyword5", "testKeywords6", "testkeyword7", "testKeywords8"}
 				So(actual, ShouldResemble, expectedKeywords)

--- a/service/service.go
+++ b/service/service.go
@@ -170,7 +170,6 @@ func (svc *Service) Close(ctx context.Context) error {
 }
 
 func registerCheckers(ctx context.Context, hc HealthChecker, zebedeeClient clients.ZebedeeClient, consumer kafka.IConsumerGroup, producer kafka.IProducer) (err error) {
-
 	hasErrors := false
 
 	if err := hc.AddCheck("Zebedee client", zebedeeClient.Checker); err != nil {

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -201,7 +201,6 @@ func TestRun(t *testing.T) {
 
 func TestClose(t *testing.T) {
 	Convey("Having a correctly initialised service", t, func() {
-
 		hcStopped := false
 
 		zebedeeMock := &clientMock.ZebedeeClientMock{


### PR DESCRIPTION
### What

- This adds the golangci linter to the dp-search-reindex-api repo. This PR enables the following linters via .golangci.yml
`
    - deadcode
    - depguard
    - dogsled
    - errcheck
    - gochecknoinits
    - goconst
    - gocritic
    - gocyclo
    - gofmt
    - goimports
    - revive
    - gosec
    - gosimple
    - govet
    - ineffassign
    - nakedret
    - staticcheck
    - structcheck
    - stylecheck
    - typecheck
    - unconvert
    - unused
    - varcheck
    - whitespace
    - gocognit
    - prealloc`

This PR also attempts to fix the existing lint issues with the repo. **Please Note** in .golangci.yaml linter configuration file there is an parameter under issues attribute reffered to as `new` I have set it to false (default), but when you set it to true then it will ignore all the existing lint issues and will flag only the new lint issues. 

### How to review

Please have a look into the .golangcilint.yml file and see if the linters listed here make sense , also if you would like to add any additional linters we can always do that . For the first pass I think we have enough linters enabled (mentioned above). 
