### PR TITLE
Add URI to CMDData

### DIFF
--- a/models/mapper.go
+++ b/models/mapper.go
@@ -19,7 +19,7 @@ func MapZebedeeDataToSearchDataImport(zebedeeData ZebedeeData, keywordsLimit int
 		Summary:         zebedeeData.Description.Summary,
 		ReleaseDate:     zebedeeData.Description.ReleaseDate,
 		Title:           zebedeeData.Description.Title,
-		Topics:          ValidateTopics(zebedeeData.Description.Topics),
+		Topics:          zebedeeData.Description.Topics,
 	}
 	return searchData
 }
@@ -62,6 +62,7 @@ func ValidateTopics(topics []string) []string {
 func MapVersionMetadataToSearchDataImport(cmdData CMDData) SearchDataImport {
 	versionMetaData := SearchDataImport{
 		UID:             cmdData.UID,
+		URI:             cmdData.URI,
 		ReleaseDate:     cmdData.VersionDetails.ReleaseDate,
 		Keywords:        cmdData.DatasetDetails.Keywords,
 		MetaDescription: cmdData.DatasetDetails.Description,

--- a/models/metadata.go
+++ b/models/metadata.go
@@ -3,6 +3,7 @@ package models
 // CMDData provides model for datasetAPI metadata response
 type CMDData struct {
 	UID            string         `json:"uid"`
+	URI            string         `json:"uri"`
 	VersionDetails VersionDetails `json:"version"`
 	DatasetDetails DatasetDetails `json:"datasetdetails"`
 }


### PR DESCRIPTION
### What
This pr does the following: 

- Add URI to cmd data
- Remove topic validation. This is because according to the ES7.10 template mapping, the topics is a ```nested``` type property and in validation it was returning for all topics that are nil as ```[]string{""}```. This is being ignored by the ES 7.10 as this was not matching the mappings structure of the document. 

### How to review

Already tested against the develop. 

### Who can review

Anyone except me. 
