### PR TITLE
Update model to include missing release calendar fields

### DIFF
--- a/.nancy-ignore
+++ b/.nancy-ignore
@@ -1,2 +1,6 @@
 CVE-2020-26160 # No upgrade path for github.com/dgrijalva/jwt-go. See: https://ossindex.sonatype.org/vulnerability/c16fb56d-9de6-4065-9fca-d2b4cfb13020?component-type=golang&component-name=github.com%2Fdgrijalva%2Fjwt-go&utm_source=nancy-client&utm_medium=integration&utm_content=0.0.0-dev
-
+sonatype-2021-4899 #  1 non-CVE vulnerability found. To see more details, please create a free account at https://ossindex.sonatype.org/ and request for this information using your registered account
+CVE-2022-29153 # HashiCorp Consul and Consul Enterprise through 2022-04-12 allow SSRF.
+CVE-2022-21698 # client_golang is the instrumentation library for Go applications in  Prometheus, and the promhttp package in client_golang provides tooling  around HTTP servers and clients. In client_golang prior to version 1.11.1, HTTP server is susceptible to a Denial of Service through unbounded cardinality, and potential memory exhaustion, when handling requests with  non-standard HTTP methods.
+sonatype-2021-1401 # 1 non-CVE vulnerability found. To see more details, please create a free account at https://ossindex.sonatype.org/ and request for this information using your registered account
+sonatype-2019-0890 # 1 non-CVE vulnerability found. To see more details, please create an account at https://ossindex.sonatype.org/ and request for this information using your registered account

--- a/event/producer_test.go
+++ b/event/producer_test.go
@@ -40,6 +40,11 @@ var (
 		ReleaseDate:     "",
 		Title:           "",
 		Topics:          []string{""},
+		DateChanges:     []models.ReleaseDateDetails{{}},
+		Cancelled:       false,
+		Finalised:       false,
+		ProvisionalDate: "",
+		Published:       false,
 	}
 
 	expectedVersionMetadataEvent = models.SearchDataImport{

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -100,7 +100,6 @@ func (h *ContentPublishedHandler) Handle(ctx context.Context, cpEvent *models.Co
 			log.Error(ctx, "cannot get dataset published contents version %s from api", metadataErr)
 			return metadataErr
 		}
-
 		logData = log.Data{
 			"uid generated":    generatedID,
 			"contentPublished": datasetMetadataPublished,

--- a/models/event.go
+++ b/models/event.go
@@ -12,18 +12,29 @@ type ContentPublished struct {
 
 // SearchDataImport provides event data for a search data import
 type SearchDataImport struct {
-	UID             string   `avro:"uid"`
-	URI             string   `avro:"uri"`
-	DataType        string   `avro:"data_type"`
-	JobID           string   `avro:"job_id"`
-	SearchIndex     string   `avro:"search_index"`
-	CDID            string   `avro:"cdid"`
-	DatasetID       string   `avro:"dataset_id"`
-	Keywords        []string `avro:"keywords"`
-	MetaDescription string   `avro:"meta_description"`
-	ReleaseDate     string   `avro:"release_date"`
-	Summary         string   `avro:"summary"`
-	Title           string   `avro:"title"`
-	Topics          []string `avro:"topics"`
-	TraceID         string   `avro:"trace_id"`
+	UID             string               `avro:"uid"`
+	URI             string               `avro:"uri"`
+	DataType        string               `avro:"data_type"`
+	JobID           string               `avro:"job_id"`
+	SearchIndex     string               `avro:"search_index"`
+	CDID            string               `avro:"cdid"`
+	DatasetID       string               `avro:"dataset_id"`
+	Keywords        []string             `avro:"keywords"`
+	MetaDescription string               `avro:"meta_description"`
+	ReleaseDate     string               `avro:"release_date"`
+	Summary         string               `avro:"summary"`
+	Title           string               `avro:"title"`
+	Topics          []string             `avro:"topics"`
+	TraceID         string               `avro:"trace_id"`
+	DateChanges     []ReleaseDateDetails `avro:"date_changes"`
+	Cancelled       bool                 `avro:"cancelled"`
+	Finalised       bool                 `avro:"finalised"`
+	ProvisionalDate string               `avro:"provisional_date"`
+	Published       bool                 `avro:"published"`
+}
+
+// ReleaseDateChange represent a date change of a release
+type ReleaseDateDetails struct {
+	ChangeNotice string `avro:"change_notice"`
+	Date         string `avro:"previous_date"`
 }

--- a/models/mapper.go
+++ b/models/mapper.go
@@ -1,7 +1,14 @@
 package models
 
 import (
+	"context"
 	"strings"
+
+	"github.com/ONSdigital/log.go/v2/log"
+)
+
+const (
+	ReleaseDataType = "release"
 )
 
 // MapZebedeeDataToSearchDataImport Performs default mapping of zebedee data to a SearchDataImport struct.
@@ -20,6 +27,19 @@ func MapZebedeeDataToSearchDataImport(zebedeeData ZebedeeData, keywordsLimit int
 		ReleaseDate:     zebedeeData.Description.ReleaseDate,
 		Title:           zebedeeData.Description.Title,
 		Topics:          zebedeeData.Description.Topics,
+	}
+	if zebedeeData.DataType == ReleaseDataType {
+		logData := log.Data{
+			"zebedeeRCData": zebedeeData,
+		}
+		log.Info(context.Background(), "zebedee release calender data", logData)
+		for _, data := range zebedeeData.DateChanges {
+			searchData.DateChanges = append(searchData.DateChanges, ReleaseDateDetails(data))
+		}
+		searchData.Published = zebedeeData.Published
+		searchData.Cancelled = zebedeeData.Cancelled
+		searchData.Finalised = zebedeeData.Finalised
+		searchData.ProvisionalDate = zebedeeData.ProvisionalDate
 	}
 	return searchData
 }

--- a/models/zebedee.go
+++ b/models/zebedee.go
@@ -2,10 +2,15 @@ package models
 
 // ZebedeeData provides model for zebedee publisheddata response
 type ZebedeeData struct {
-	UID         string      `json:"uid"`
-	URI         string      `json:"uri"`
-	DataType    string      `json:"type"`
-	Description Description `json:"description"`
+	UID             string              `json:"uid"`
+	URI             string              `json:"uri"`
+	DataType        string              `json:"type"`
+	Description     Description         `json:"description"`
+	DateChanges     []ReleaseDateChange `json:"date_changes,omitempty"`
+	Cancelled       bool                `json:"cancelled,omitempty"`
+	Finalised       bool                `json:"finalised,omitempty"`
+	ProvisionalDate string              `json:"provisional_date,omitempty"`
+	Published       bool                `json:"published,omitempty"`
 }
 
 type Description struct {
@@ -18,4 +23,10 @@ type Description struct {
 	Summary         string   `json:"summary"`
 	Title           string   `json:"title"`
 	Topics          []string `json:"topics,omitempty"`
+}
+
+// ReleaseDateChange represent a date change of a release
+type ReleaseDateChange struct {
+	ChangeNotice string `json:"change_notice"`
+	Date         string `json:"previous_date"`
 }

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -39,7 +39,18 @@ var searchDataImport = `{
     {"name": "summary", "type": "string", "default": ""},
     {"name": "title", "type": "string", "default": ""},
     {"name": "topics", "type": {"type":"array","items":"string"}},
-    {"name": "trace_id", "type": "string", "default": ""}
+    {"name": "trace_id", "type": "string", "default": ""},
+    {"name": "cancelled", "type": "boolean", "default": false},
+    {"name": "finalised", "type": "boolean", "default": false},
+    {"name": "published", "type": "boolean", "default": false},
+    {"name": "date_changes", "type": {"type":"array","items":{
+     "name": "ReleaseDateDetails",
+     "type" : "record",
+     "fields" : [
+      {"name": "change_notice", "type": "string", "default": ""},
+      {"name": "previous_date", "type": "string", "default": ""}
+    ]}}},
+    {"name": "provisional_date", "type": "string", "default": ""}
   ]
 }`
 


### PR DESCRIPTION
### What

This pr includes the following:
Extension to the new search service to handle data fields for release calendar previously not considered due to not being needed by sitesearch.

The below field extensions are for the content **type**: `release`

### How to review

Trello ticket: https://trello.com/c/4mlvciPr/1256-search-data-extractor-update-model-to-include-missing-release-calendar-fields-incl-updating-transform
This pr is done according to the above trello ticket. 

### Who can review

Anyone except me
