### PR TITLE
Release/0.17.0

### DIFF
--- a/models/event.go
+++ b/models/event.go
@@ -30,6 +30,7 @@ type SearchDataImport struct {
 	Cancelled       bool                 `avro:"cancelled"`
 	Finalised       bool                 `avro:"finalised"`
 	ProvisionalDate string               `avro:"provisional_date"`
+	CanonicalTopic  string               `avro:"canonical_topic"`
 	Published       bool                 `avro:"published"`
 	Language        string               `avro:"language"`
 	Survey          string               `avro:"survey"`

--- a/models/mapper.go
+++ b/models/mapper.go
@@ -42,6 +42,7 @@ func MapZebedeeDataToSearchDataImport(zebedeeData ZebedeeData, keywordsLimit int
 		searchData.ProvisionalDate = zebedeeData.Description.ProvisionalDate
 		searchData.Survey = zebedeeData.Description.Survey
 		searchData.Language = zebedeeData.Description.Language
+		searchData.CanonicalTopic = zebedeeData.Description.CanonicalTopic
 	}
 	return searchData
 }

--- a/models/mapper_test.go
+++ b/models/mapper_test.go
@@ -27,6 +27,7 @@ const (
 	someTitle           = "Some Incredible Title"
 	someSurvey          = "Some survey"
 	someLanguage        = "some language"
+	canonicalTopic      = "some topic"
 
 	sometopic0 = "topic0"
 	sometopic1 = "topic1"
@@ -59,6 +60,7 @@ func TestMapZebedeeDataToSearchDataImport(t *testing.T) {
 				Topics:          []string{sometopic0, sometopic1},
 				Survey:          someSurvey,
 				Language:        someLanguage,
+				CanonicalTopic:  canonicalTopic,
 			},
 		}
 		Convey("When mapped with a default keywords limit", func() {
@@ -74,6 +76,7 @@ func TestMapZebedeeDataToSearchDataImport(t *testing.T) {
 				So(result.Title, ShouldResemble, someTitle)
 				So(result.Survey, ShouldResemble, someSurvey)
 				So(result.Language, ShouldResemble, someLanguage)
+				So(result.CanonicalTopic, ShouldResemble, canonicalTopic)
 
 				So(result.DateChanges, ShouldHaveLength, 1)
 				So(result.DateChanges[0].ChangeNotice, ShouldEqual, someChangeNotice)

--- a/models/zebedee.go
+++ b/models/zebedee.go
@@ -18,11 +18,12 @@ type Description struct {
 	Keywords        []string `json:"keywords,omitempty"`
 	MetaDescription string   `json:"metaDescription"`
 	ProvisionalDate string   `json:"provisionalDate,omitempty"`
+	CanonicalTopic  string   `json:"canonicalTopic,omitempty"`
 	Published       bool     `json:"published,omitempty"`
 	ReleaseDate     string   `json:"releaseDate"`
 	Summary         string   `json:"summary"`
 	Title           string   `json:"title"`
-	Topics          []string `json:"topics,omitempty"`
+	Topics          []string `json:"secondaryTopics,omitempty"`
 	Language        string   `json:"language,omitempty"`
 	Survey          string   `json:"survey,omitempty"`
 }

--- a/models/zebedee.go
+++ b/models/zebedee.go
@@ -6,7 +6,7 @@ type ZebedeeData struct {
 	URI         string              `json:"uri"`
 	DataType    string              `json:"type"`
 	Description Description         `json:"description"`
-	DateChanges []ReleaseDateChange `json:"date_changes,omitempty"`
+	DateChanges []ReleaseDateChange `json:"dateChanges,omitempty"`
 }
 
 type Description struct {
@@ -17,7 +17,7 @@ type Description struct {
 	Finalised       bool     `json:"finalised,omitempty"`
 	Keywords        []string `json:"keywords,omitempty"`
 	MetaDescription string   `json:"metaDescription"`
-	ProvisionalDate string   `json:"provisional_date,omitempty"`
+	ProvisionalDate string   `json:"provisionalDate,omitempty"`
 	Published       bool     `json:"published,omitempty"`
 	ReleaseDate     string   `json:"releaseDate"`
 	Summary         string   `json:"summary"`
@@ -29,6 +29,6 @@ type Description struct {
 
 // ReleaseDateChange represent a date change of a release
 type ReleaseDateChange struct {
-	ChangeNotice string `json:"change_notice"`
-	Date         string `json:"previous_date"`
+	ChangeNotice string `json:"changeNotice"`
+	Date         string `json:"previousDate"`
 }

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -45,6 +45,7 @@ var searchDataImport = `{
     {"name": "published", "type": "boolean", "default": false},
     {"name": "language", "type": "string", "default": ""},
     {"name": "survey",   "type": "string", "default": ""},
+    {"name": "canonical_topic",   "type": "string", "default": ""},
     {"name": "date_changes", "type": {"type":"array","items":{
      "name": "ReleaseDateDetails",
      "type" : "record",


### PR DESCRIPTION
### What

This release pr contains the following changes:

- Add canonicalTopic and map secondary topics to topics
- Align the json tags with the attributes names that will be exported from Zebedee

### How to review

See if these changes make sense

### Who can review

Anyone except me
