### PR TITLE
fix use of time.After() to clean up timer resource

### DIFF
--- a/event/producer_test.go
+++ b/event/producer_test.go
@@ -93,10 +93,11 @@ func TestProducer_SearchDataImport(t *testing.T) {
 
 			var avroBytes []byte
 			var testTimeout = time.Second * 5
+			delay := time.NewTimer(testTimeout)
 			select {
 			case avroBytes = <-pChannels.Output:
 				t.Log("avro byte sent to producer output")
-			case <-time.After(testTimeout):
+			case <-delay.C:
 				t.Fatalf("failing test due to timing out after %v seconds", testTimeout)
 				t.FailNow()
 			}
@@ -180,10 +181,11 @@ func TestProducer_SearchDatasetVersionMetadataImport(t *testing.T) {
 
 			var avroBytes []byte
 			var testTimeout = time.Second * 5
+			delay := time.NewTimer(testTimeout)
 			select {
 			case avroBytes = <-pChannels.Output:
 				t.Log("avro byte sent to producer output")
-			case <-time.After(testTimeout):
+			case <-delay.C:
 				t.Fatalf("failing test due to timing out after %v seconds", testTimeout)
 				t.FailNow()
 			}

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -134,10 +134,11 @@ func TestHandlerForZebedeeReturningMandatoryFields(t *testing.T) {
 			})
 
 			var avroBytes []byte
+			delay := time.NewTimer(testTimeout)
 			select {
 			case avroBytes = <-pChannels.Output:
 				t.Log("avro byte sent to producer output")
-			case <-time.After(testTimeout):
+			case <-delay.C:
 				t.FailNow()
 			}
 			Convey("And then the expected bytes are sent to producer.output", func() {
@@ -172,10 +173,11 @@ func TestHandlerForZebedeeReturningMandatoryFields(t *testing.T) {
 
 				So(len(datasetMock.GetVersionMetadataCalls()), ShouldEqual, 0)
 			})
+			delay := time.NewTimer(testTimeout)
 			select {
 			case <-pChannels.Output:
 				t.Log("avro byte sent to producer output")
-			case <-time.After(testTimeout):
+			case <-delay.C:
 				t.FailNow()
 			}
 		})
@@ -246,10 +248,11 @@ func TestHandlerForZebedeeReturningAllFields(t *testing.T) {
 			err := eventHandler.Handle(ctx, &testZebedeeEvent, *cfg)
 
 			var avroBytes []byte
+			delay := time.NewTimer(testTimeout)
 			select {
 			case avroBytes = <-pChannels.Output:
 				t.Log("avro byte sent to producer output")
-			case <-time.After(testTimeout):
+			case <-delay.C:
 				t.FailNow()
 			}
 			Convey("Then no error is reported", func() {
@@ -327,10 +330,11 @@ func TestHandlerForDatasetVersionMetadata(t *testing.T) {
 			err := eventHandler.Handle(ctx, &testDatasetEvent, *cfg)
 
 			var avroBytes []byte
+			delay := time.NewTimer(testTimeout)
 			select {
 			case avroBytes = <-pChannels.Output:
 				t.Log("avro byte sent to producer output")
-			case <-time.After(testTimeout):
+			case <-delay.C:
 				t.FailNow()
 			}
 


### PR DESCRIPTION
### What
**Describe what you have changed and why.**
- Fix use of `time.After()` to clean up the timer resource
- This eliminates resource leakage due to using `time.After()` in wrong manner

### How to review
**Describe the steps required to test the changes.**
- Check if the code changes make sense
- Check if the test passes

### Who can review
**Describe who worked on the changes, so that other people can review.**
- Anyone