### PR TITLE
use `time.NewTimer` instead of `time.After()`

### DIFF
--- a/event/producer_test.go
+++ b/event/producer_test.go
@@ -93,10 +93,16 @@ func TestProducer_SearchDataImport(t *testing.T) {
 
 			var avroBytes []byte
 			var testTimeout = time.Second * 5
+			delay := time.NewTimer(testTimeout)
 			select {
 			case avroBytes = <-pChannels.Output:
+				// Ensure timer is stopped and its resources are freed
+				if !delay.Stop() {
+					// if the timer has been stopped then read from the channel
+					<-delay.C
+				}
 				t.Log("avro byte sent to producer output")
-			case <-time.After(testTimeout):
+			case <-delay.C:
 				t.Fatalf("failing test due to timing out after %v seconds", testTimeout)
 				t.FailNow()
 			}
@@ -180,10 +186,16 @@ func TestProducer_SearchDatasetVersionMetadataImport(t *testing.T) {
 
 			var avroBytes []byte
 			var testTimeout = time.Second * 5
+			delay := time.NewTimer(testTimeout)
 			select {
 			case avroBytes = <-pChannels.Output:
+				// Ensure timer is stopped and its resources are freed
+				if !delay.Stop() {
+					// if the timer has been stopped then read from the channel
+					<-delay.C
+				}
 				t.Log("avro byte sent to producer output")
-			case <-time.After(testTimeout):
+			case <-delay.C:
 				t.Fatalf("failing test due to timing out after %v seconds", testTimeout)
 				t.FailNow()
 			}

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -134,10 +134,16 @@ func TestHandlerForZebedeeReturningMandatoryFields(t *testing.T) {
 			})
 
 			var avroBytes []byte
+			delay := time.NewTimer(testTimeout)
 			select {
 			case avroBytes = <-pChannels.Output:
+				// Ensure timer is stopped and its resources are freed
+				if !delay.Stop() {
+					// if the timer has been stopped then read from the channel
+					<-delay.C
+				}
 				t.Log("avro byte sent to producer output")
-			case <-time.After(testTimeout):
+			case <-delay.C:
 				t.FailNow()
 			}
 			Convey("And then the expected bytes are sent to producer.output", func() {
@@ -172,10 +178,16 @@ func TestHandlerForZebedeeReturningMandatoryFields(t *testing.T) {
 
 				So(len(datasetMock.GetVersionMetadataCalls()), ShouldEqual, 0)
 			})
+			delay := time.NewTimer(testTimeout)
 			select {
 			case <-pChannels.Output:
+				// Ensure timer is stopped and its resources are freed
+				if !delay.Stop() {
+					// if the timer has been stopped then read from the channel
+					<-delay.C
+				}
 				t.Log("avro byte sent to producer output")
-			case <-time.After(testTimeout):
+			case <-delay.C:
 				t.FailNow()
 			}
 		})
@@ -246,10 +258,16 @@ func TestHandlerForZebedeeReturningAllFields(t *testing.T) {
 			err := eventHandler.Handle(ctx, &testZebedeeEvent, *cfg)
 
 			var avroBytes []byte
+			delay := time.NewTimer(testTimeout)
 			select {
 			case avroBytes = <-pChannels.Output:
+				// Ensure timer is stopped and its resources are freed
+				if !delay.Stop() {
+					// if the timer has been stopped then read from the channel
+					<-delay.C
+				}
 				t.Log("avro byte sent to producer output")
-			case <-time.After(testTimeout):
+			case <-delay.C:
 				t.FailNow()
 			}
 			Convey("Then no error is reported", func() {
@@ -327,10 +345,16 @@ func TestHandlerForDatasetVersionMetadata(t *testing.T) {
 			err := eventHandler.Handle(ctx, &testDatasetEvent, *cfg)
 
 			var avroBytes []byte
+			delay := time.NewTimer(testTimeout)
 			select {
 			case avroBytes = <-pChannels.Output:
+				// Ensure timer is stopped and its resources are freed
+				if !delay.Stop() {
+					// if the timer has been stopped then read from the channel
+					<-delay.C
+				}
 				t.Log("avro byte sent to producer output")
-			case <-time.After(testTimeout):
+			case <-delay.C:
 				t.FailNow()
 			}
 


### PR DESCRIPTION
### What
**Describe what you have changed and why.**
- Use `time.NewTimer` instead of `time.After()`

### How to review
**Describe the steps required to test the changes.**
- Check if the code changes make sense

### Who can review
**Describe who worked on the changes, so that other people can review.**
- Anyone