### PR TITLE
Refactor and correct job id and search index name values

### DIFF
--- a/handler/handler.go
+++ b/handler/handler.go
@@ -70,7 +70,7 @@ func (h *ContentPublishedHandler) Handle(ctx context.Context, cpEvent *models.Co
 		// Mapping Json to Avro
 		searchData := models.MapZebedeeDataToSearchDataImport(zebedeeData, cfg.KeywordsLimit)
 		searchData.TraceID = cpEvent.TraceID
-		searchData.JobID = cpEvent.SearchIndex
+		searchData.JobID = cpEvent.JobID
 		searchData.SearchIndex = getIndexName(cpEvent.SearchIndex)
 
 		// Marshall Avro and sending message

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -70,8 +70,8 @@ func (h *ContentPublishedHandler) Handle(ctx context.Context, cpEvent *models.Co
 		// Mapping Json to Avro
 		searchData := models.MapZebedeeDataToSearchDataImport(zebedeeData, cfg.KeywordsLimit)
 		searchData.TraceID = cpEvent.TraceID
-		searchData.JobID = ""
-		searchData.SearchIndex = OnsSearchIndex
+		searchData.JobID = cpEvent.SearchIndex
+		searchData.SearchIndex = getIndexName(cpEvent.SearchIndex)
 
 		// Marshall Avro and sending message
 		if sdImportErr := h.Producer.SearchDataImport(ctx, searchData); sdImportErr != nil {
@@ -125,9 +125,10 @@ func (h *ContentPublishedHandler) Handle(ctx context.Context, cpEvent *models.Co
 			"datasetVersionData": datasetVersionMetadata,
 		}
 		log.Info(ctx, "datasetVersionMetadata ", logData)
+
 		datasetVersionMetadata.TraceID = cpEvent.TraceID
-		datasetVersionMetadata.JobID = ""
-		datasetVersionMetadata.SearchIndex = OnsSearchIndex
+		datasetVersionMetadata.JobID = cpEvent.JobID
+		datasetVersionMetadata.SearchIndex = getIndexName(cpEvent.SearchIndex)
 		datasetVersionMetadata.DataType = "dataset_landing_page"
 
 		// Marshall Avro and sending message
@@ -185,4 +186,12 @@ func extractDatasetURI(editionURI string) (string, error) {
 	datasetURI := strings.Join(slicedURI, "/")
 
 	return datasetURI, nil
+}
+
+func getIndexName(indexName string) string {
+	if indexName != "" {
+		return indexName
+	}
+
+	return OnsSearchIndex
 }

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -37,21 +37,15 @@ func (h *ContentPublishedHandler) Handle(ctx context.Context, cpEvent *models.Co
 	var zebedeeContentPublished []byte
 	var err error
 	if cpEvent.DataType == ZebedeeDataType {
-		if strings.Contains(cpEvent.URI, DatasetDataType) {
-			datasetURI, datasetErr := extractDatasetURI(cpEvent.URI)
-			if datasetErr != nil {
-				return datasetErr
-			}
-			zebedeeContentPublished, err = h.ZebedeeCli.GetPublishedData(ctx, datasetURI)
-			if err != nil {
-				return err
-			}
-		} else {
-			// Make a call to Zebedee
-			zebedeeContentPublished, err = h.ZebedeeCli.GetPublishedData(ctx, cpEvent.URI)
-			if err != nil {
-				return err
-			}
+		// obtain correct uri to callback to Zebedee to retrieve content metadata
+		uri, err := retrieveCorrectURI(cpEvent.URI)
+		if err != nil {
+			return err
+		}
+
+		zebedeeContentPublished, err = h.ZebedeeCli.GetPublishedData(ctx, uri)
+		if err != nil {
+			return err
 		}
 
 		logData = log.Data{
@@ -165,13 +159,30 @@ func getIDsFromURI(uri string) (datasetID, editionID, versionID string, err erro
 	return
 }
 
+func retrieveCorrectURI(uri string) (correctURI string, err error) {
+	correctURI = uri
+
+	// Remove edition segment of path from Zebedee dataset uri to
+	// enable retrieval of the dataset resource for edition
+	if strings.Contains(uri, DatasetDataType) {
+		correctURI, err = extractDatasetURI(uri)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	return correctURI, nil
+}
+
 func extractDatasetURI(editionURI string) (string, error) {
 	parsedURI, err := url.Parse(editionURI)
 	if err != nil {
 		return "", err
 	}
+
 	slicedURI := strings.Split(parsedURI.Path, "/")
 	slicedURI = slicedURI[:len(slicedURI)-1]
 	datasetURI := strings.Join(slicedURI, "/")
+
 	return datasetURI, nil
 }

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -1,4 +1,4 @@
-package handler_test
+package handler
 
 import (
 	"context"
@@ -12,7 +12,6 @@ import (
 	"github.com/ONSdigital/dp-search-data-extractor/config"
 	"github.com/ONSdigital/dp-search-data-extractor/event"
 	"github.com/ONSdigital/dp-search-data-extractor/event/mock"
-	"github.com/ONSdigital/dp-search-data-extractor/handler"
 	"github.com/ONSdigital/dp-search-data-extractor/models"
 	"github.com/ONSdigital/dp-search-data-extractor/schema"
 
@@ -117,7 +116,7 @@ func TestHandlerForZebedeeReturningMandatoryFields(t *testing.T) {
 		var zebedeeMock = &clientMock.ZebedeeClientMock{GetPublishedDataFunc: getPublishDataFunc}
 		var datasetMock = &clientMock.DatasetClientMock{GetVersionMetadataFunc: getVersionMetadataFunc}
 
-		eventHandler := &handler.ContentPublishedHandler{zebedeeMock, datasetMock, *producerMock}
+		eventHandler := &ContentPublishedHandler{zebedeeMock, datasetMock, *producerMock}
 
 		Convey("When given a valid event", func() {
 			err := eventHandler.Handle(ctx, &testZebedeeEvent, *cfg)
@@ -195,7 +194,7 @@ func TestHandlerForZebedeeReturningMandatoryFields(t *testing.T) {
 	Convey("Given an event handler not working successfully, and an event containing a URI", t, func() {
 		var zebedeeMockInError = &clientMock.ZebedeeClientMock{GetPublishedDataFunc: getPublishDataFuncInError}
 		var datasetMockInError = &clientMock.DatasetClientMock{GetVersionMetadataFunc: getVersionMetadataFuncInError}
-		eventHandler := &handler.ContentPublishedHandler{zebedeeMockInError, datasetMockInError, *producerMock}
+		eventHandler := &ContentPublishedHandler{zebedeeMockInError, datasetMockInError, *producerMock}
 
 		Convey("When given a valid event", func() {
 			err := eventHandler.Handle(ctx, &testZebedeeEvent, *cfg)
@@ -252,7 +251,7 @@ func TestHandlerForZebedeeReturningAllFields(t *testing.T) {
 
 		var zebedeeMock = &clientMock.ZebedeeClientMock{GetPublishedDataFunc: getFullPublishDataFunc}
 		var datasetMock = &clientMock.DatasetClientMock{GetVersionMetadataFunc: getVersionMetadataFunc}
-		eventHandler := &handler.ContentPublishedHandler{zebedeeMock, datasetMock, *producerMock}
+		eventHandler := &ContentPublishedHandler{zebedeeMock, datasetMock, *producerMock}
 
 		Convey("When given a valid event with default keywords limit", func() {
 			err := eventHandler.Handle(ctx, &testZebedeeEvent, *cfg)
@@ -339,7 +338,7 @@ func TestHandlerForDatasetVersionMetadata(t *testing.T) {
 		var zebedeeMock = &clientMock.ZebedeeClientMock{GetPublishedDataFunc: getPublishDataFunc}
 		var datasetMock = &clientMock.DatasetClientMock{GetVersionMetadataFunc: getVersionMetadataFunc}
 
-		eventHandler := &handler.ContentPublishedHandler{zebedeeMock, datasetMock, *producerMock}
+		eventHandler := &ContentPublishedHandler{zebedeeMock, datasetMock, *producerMock}
 
 		Convey("When given a valid event for cmd dataset", func() {
 			err := eventHandler.Handle(ctx, &testDatasetEvent, *cfg)
@@ -383,7 +382,7 @@ func TestHandlerForDatasetVersionMetadata(t *testing.T) {
 	Convey("Given an event handler not working successfully, and an event containing a valid dataType", t, func() {
 		var zebedeeMockInError = &clientMock.ZebedeeClientMock{GetPublishedDataFunc: getPublishDataFuncInError}
 		var datasetMockInError = &clientMock.DatasetClientMock{GetVersionMetadataFunc: getVersionMetadataFuncInError}
-		eventHandler := &handler.ContentPublishedHandler{zebedeeMockInError, datasetMockInError, *producerMock}
+		eventHandler := &ContentPublishedHandler{zebedeeMockInError, datasetMockInError, *producerMock}
 
 		Convey("When given a valid event for a valid dataset", func() {
 			err := eventHandler.Handle(ctx, &testDatasetEvent, *cfg)
@@ -425,7 +424,7 @@ func TestHandlerForInvalidDataType(t *testing.T) {
 	Convey("Given an event handler working successfully, and an event containing a invalid dataType", t, func() {
 		var zebedeeMockInError = &clientMock.ZebedeeClientMock{GetPublishedDataFunc: getPublishDataFuncInError}
 		var datasetMockInError = &clientMock.DatasetClientMock{GetVersionMetadataFunc: getVersionMetadataFuncInError}
-		eventHandler := &handler.ContentPublishedHandler{zebedeeMockInError, datasetMockInError, *producerMock}
+		eventHandler := &ContentPublishedHandler{zebedeeMockInError, datasetMockInError, *producerMock}
 
 		Convey("When given a invalid event", func() {
 			err := eventHandler.Handle(ctx, &testInvalidEvent, *cfg)
@@ -438,6 +437,56 @@ func TestHandlerForInvalidDataType(t *testing.T) {
 
 				So(datasetMockInError.GetVersionMetadataCalls(), ShouldHaveLength, 0)
 				So(datasetMockInError.GetVersionMetadataCalls(), ShouldBeEmpty)
+			})
+		})
+	})
+}
+
+func TestExtractDatasetURIFromEditionURI(t *testing.T) {
+	t.Parallel()
+
+	Convey("Given a valid edition uri", t, func() {
+		editionURI := "/datasets/uk-economy/2016"
+		expectedURI := "/datasets/uk-economy"
+
+		Convey("When calling extractDatasetURI function", func() {
+			datasetURI, err := extractDatasetURI(editionURI)
+
+			Convey("Then successfully return a dataset uri and no errors", func() {
+				So(err, ShouldBeNil)
+				So(datasetURI, ShouldEqual, expectedURI)
+			})
+		})
+	})
+}
+
+func TestRetrieveCorrectURI(t *testing.T) {
+	t.Parallel()
+
+	Convey("Given a valid edition uri", t, func() {
+		editionURI := "/datasets/uk-economy/2016"
+		expectedURI := "/datasets/uk-economy"
+
+		Convey("When calling retrieveCorrectURI function", func() {
+			datasetURI, err := retrieveCorrectURI(editionURI)
+
+			Convey("Then successfully return a dataset uri and no errors", func() {
+				So(err, ShouldBeNil)
+				So(datasetURI, ShouldEqual, expectedURI)
+			})
+		})
+	})
+
+	Convey("Given a valid uri which does not contain \"datasets\"", t, func() {
+		bulletinURI := "/bulletins/uk-economy/2016"
+		expectedURI := "/bulletins/uk-economy/2016"
+
+		Convey("When calling retrieveCorrectURI function", func() {
+			datasetURI, err := retrieveCorrectURI(bulletinURI)
+
+			Convey("Then successfully return the original uri and no errors", func() {
+				So(err, ShouldBeNil)
+				So(datasetURI, ShouldEqual, expectedURI)
 			})
 		})
 	})

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -492,6 +492,36 @@ func TestRetrieveCorrectURI(t *testing.T) {
 	})
 }
 
+func TestGetIndexName(t *testing.T) {
+	t.Parallel()
+
+	Convey("Given index name is not empty", t, func() {
+		index := "ons123456789"
+		expectedIndex := index
+
+		Convey("When calling getIndexName function", func() {
+			indexName := getIndexName(index)
+
+			Convey("Then successfully return the original index name", func() {
+				So(indexName, ShouldEqual, expectedIndex)
+			})
+		})
+	})
+
+	Convey("Given index name is empty", t, func() {
+		index := ""
+		expectedIndex := OnsSearchIndex
+
+		Convey("When calling getIndexName function", func() {
+			indexName := getIndexName(index)
+
+			Convey("Then successfully return the default index name", func() {
+				So(indexName, ShouldEqual, expectedIndex)
+			})
+		})
+	})
+}
+
 // marshalSearchDataImport helper method to marshal a event into a []byte
 func marshalSearchDataImport(t *testing.T, sdEvent models.SearchDataImport) []byte {
 	bytes, err := schema.SearchDataImportEvent.Marshal(sdEvent)


### PR DESCRIPTION
### What

Refactor and correct job id and search index name values based on the event consumed from content-updated topic

### How to review

Check the transformation of search data includes job id and search index name if set in the consumed event, if they are not set then use default index name "ons" and job_id will be set to empty string.

Check refactored code makes sense and unit tests cover new functions

### Who can review

Anyone
