### PR TITLE
keep dataset_landing_page type for cantabular types

### DIFF
--- a/cmd/producer/main.go
+++ b/cmd/producer/main.go
@@ -34,7 +34,7 @@ func main() {
 		KafkaVersion:    &cfg.Kafka.Version,
 		MaxMessageBytes: &cfg.Kafka.MaxBytes,
 	}
-	if cfg.Kafka.SecProtocol == config.KafkaTLSProtocolFlag {
+	if cfg.Kafka.SecProtocol == config.KafkaTLSProtocol {
 		pConfig.SecurityConfig = kafka.GetSecurityConfig(
 			cfg.Kafka.SecCACerts,
 			cfg.Kafka.SecClientCert,

--- a/config/config.go
+++ b/config/config.go
@@ -6,8 +6,8 @@ import (
 	"github.com/kelseyhightower/envconfig"
 )
 
-// KafkaTLSProtocolFlag informs service to use TLS protocol for kafka
-const KafkaTLSProtocolFlag = "TLS"
+// KafkaTLSProtocol informs service to use TLS protocol for kafka
+const KafkaTLSProtocol = "TLS"
 
 // Config represents service configuration for dp-search-data-extractor
 type Config struct {

--- a/features/publish_data_dataset.feature
+++ b/features/publish_data_dataset.feature
@@ -68,7 +68,7 @@ Feature: Data extractor should listen to the relevant topic and publish extracte
       {
         "UID":         "my-cantabular-dataset-my-edition",
         "Edition":     "my-edition",
-        "DataType":    "cantabular_flexible_table",
+        "DataType":    "dataset_landing_page",
         "SearchIndex": "ONS",
         "DatasetID":   "my-cantabular-dataset",
         "Keywords":    [ "keyword1", "keyword2" ],

--- a/features/steps/component.go
+++ b/features/steps/component.go
@@ -157,7 +157,7 @@ func (c *Component) GetKafkaConsumer(ctx context.Context, cfg *config.Kafka) (ka
 		nil,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create kafkatest consume: %w", err)
+		return nil, fmt.Errorf("failed to create kafkatest consumer: %w", err)
 	}
 	return c.KafkaConsumer.Mock, nil
 }

--- a/models/mapper_dataset.go
+++ b/models/mapper_dataset.go
@@ -81,7 +81,6 @@ func (s *SearchDataImport) PopulateCantabularFields(ctx context.Context, metadat
 		return // Dataset type is not Cantabular
 	}
 
-	s.DataType = t
 	log.Info(ctx, "identified dataset with cantabular type", log.Data{
 		"type":           t,
 		"num_dimensions": len(metadata.Dimensions)},

--- a/models/mapper_dataset_test.go
+++ b/models/mapper_dataset_test.go
@@ -154,14 +154,15 @@ func TestPopulateCantabularFields(t *testing.T) {
 
 		Convey("When PopulateCantabularFields is called on a valid search data import struct", func() {
 			s := &models.SearchDataImport{
-				Summary: testSummary,
+				Summary:  testSummary,
+				DataType: "dataset_landing_page",
 			}
 			s.PopulateCantabularFields(ctx, metadata)
 
 			Convey("Then only the non-area-type dimensions are populated, with the expected values", func() {
 				So(*s, ShouldResemble, models.SearchDataImport{
 					Summary:  testSummary,
-					DataType: "cantabular_flexible_table",
+					DataType: "dataset_landing_page",
 					Dimensions: []models.Dimension{
 						{Name: "dim1", RawLabel: "label 1 (10 categories)", Label: "label 1"},
 						{Name: "dim2", RawLabel: "label 2 (12 Categories)", Label: "label 2"},
@@ -184,14 +185,15 @@ func TestPopulateCantabularFields(t *testing.T) {
 
 		Convey("When PopulateCantabularFields is called on a valid search data import struct", func() {
 			s := &models.SearchDataImport{
-				Summary: testSummary,
+				Summary:  testSummary,
+				DataType: "dataset_landing_page",
 			}
 			s.PopulateCantabularFields(ctx, metadata)
 
 			Convey("Then the expected population type fields are populated", func() {
 				So(*s, ShouldResemble, models.SearchDataImport{
 					Summary:    testSummary,
-					DataType:   "cantabular_flexible_table",
+					DataType:   "dataset_landing_page",
 					Dimensions: []models.Dimension{},
 					PopulationType: models.PopulationType{
 						Name:  "UR_HH",

--- a/service/initialise.go
+++ b/service/initialise.go
@@ -63,7 +63,7 @@ var GetKafkaConsumer = func(ctx context.Context, cfg *config.Kafka) (kafka.ICons
 		KafkaVersion:      &cfg.Version,
 		Offset:            &kafkaOffset,
 	}
-	if cfg.SecProtocol == config.KafkaTLSProtocolFlag {
+	if cfg.SecProtocol == config.KafkaTLSProtocol {
 		cgConfig.SecurityConfig = kafka.GetSecurityConfig(
 			cfg.SecCACerts,
 			cfg.SecClientCert,
@@ -86,7 +86,7 @@ var GetKafkaProducer = func(ctx context.Context, cfg *config.Kafka) (kafka.IProd
 		KafkaVersion:      &cfg.Version,
 		MaxMessageBytes:   &cfg.MaxBytes,
 	}
-	if cfg.SecProtocol == config.KafkaTLSProtocolFlag {
+	if cfg.SecProtocol == config.KafkaTLSProtocol {
 		pConfig.SecurityConfig = kafka.GetSecurityConfig(
 			cfg.SecCACerts,
 			cfg.SecClientCert,

--- a/service/service.go
+++ b/service/service.go
@@ -136,7 +136,7 @@ func (svc *Service) Close(ctx context.Context) error {
 			}
 		}
 
-		// stop any incoming requests before closing any outbound connections
+		// Shutdown the HTTP server
 		if svc.Server != nil {
 			log.Info(ctx, "shutting http server down...")
 			if err := svc.Server.Shutdown(ctx); err != nil {


### PR DESCRIPTION
### What

[Trello card](https://trello.com/c/W6dz9w4e/1307-1307-search-data-extractor-set-datasetlandingpage-type-for-cantabular-types)

Cantabular datasets need to keep the `dataset_landing_page` type in elasticsearch.

### How to review

- Make sure changes make sense
- Make sure unit and component tests pass

### Who can review

Anyone