### PR TITLE
Workaround for topic cache initialisation race condition

### DIFF
--- a/cache/topic.go
+++ b/cache/topic.go
@@ -50,7 +50,7 @@ func NewTopicCache(ctx context.Context, updateInterval *time.Duration) (*TopicCa
 
 // GetData returns the topic cache requested by key and returns an empty topic if not found, not of the cache interface type or nil.
 func (tc *TopicCache) GetData(ctx context.Context, key string) (*Topic, error) {
-	if tc.Cache == nil {
+	if tc == nil || tc.Cache == nil {
 		log.Error(ctx, "topic cache not initialised", nil)
 		return nil, errors.New("topic cache not initialised")
 	}


### PR DESCRIPTION
### What

New workaround to fix race condition in topic cache due to concurrent inital population of the cache.
Full fix will require a minor redesign of part of the dp-cache library to handle synchronous initla population (as well as proper graceful shutdown of the ticker).

### How to review

Check code makes sense and tests pass.

### Who can review

Anyone