### PR TITLE
Refactor SearchDataImport mapping

### DIFF
--- a/handler/search_content_handler.go
+++ b/handler/search_content_handler.go
@@ -44,34 +44,7 @@ func (h *SearchContentHandler) Handle(ctx context.Context, _ int, msg kafka.Mess
 }
 
 func (h *SearchContentHandler) sendSearchDataImported(ctx context.Context, resource models.SearchContentUpdate) error {
-	searchDataImport := models.SearchDataImport{
-		URI:             resource.URI,
-		Title:           resource.Title,
-		DataType:        resource.ContentType,
-		Summary:         resource.Summary,
-		Survey:          resource.Survey,
-		MetaDescription: resource.MetaDescription,
-		ReleaseDate:     resource.ReleaseDate,
-		Language:        resource.Language,
-		Edition:         resource.Edition,
-		DatasetID:       resource.DatasetID,
-		CDID:            resource.CDID,
-		CanonicalTopic:  resource.CanonicalTopic,
-		Topics:          []string{},
-	}
-
-	// Assign topics only if they're not nil
-	if resource.Topics != nil {
-		searchDataImport.Topics = resource.Topics
-	}
-
-	if resource.ContentType == ReleaseDataType {
-		searchDataImport.Cancelled = resource.Cancelled
-		searchDataImport.Finalised = resource.Finalised
-		searchDataImport.Published = resource.Published
-		searchDataImport.ProvisionalDate = resource.ProvisionalDate
-		searchDataImport.DateChanges = resource.DateChanges
-	}
+	searchDataImport := models.MapResourceToSearchDataImport(resource)
 
 	// Marshall Avro and sending message
 	if err := h.Producer.Send(schema.SearchDataImportEvent, searchDataImport); err != nil {

--- a/models/mapper_resource.go
+++ b/models/mapper_resource.go
@@ -1,0 +1,34 @@
+package models
+
+// MapResourceToSearchDataImport Performs default mapping of a SearchContentUpdate struct to a SearchDataImport struct.
+func MapResourceToSearchDataImport(resource SearchContentUpdate) SearchDataImport {
+	searchDataImport := SearchDataImport{
+		URI:             resource.URI,
+		Title:           resource.Title,
+		DataType:        resource.ContentType,
+		Summary:         resource.Summary,
+		Survey:          resource.Survey,
+		MetaDescription: resource.MetaDescription,
+		ReleaseDate:     resource.ReleaseDate,
+		Language:        resource.Language,
+		Edition:         resource.Edition,
+		DatasetID:       resource.DatasetID,
+		CDID:            resource.CDID,
+		CanonicalTopic:  resource.CanonicalTopic,
+		Topics:          []string{},
+	}
+
+	// Assign topics only if they're not nil
+	if resource.Topics != nil {
+		searchDataImport.Topics = resource.Topics
+	}
+
+	if resource.ContentType == ReleaseDataType {
+		searchDataImport.Cancelled = resource.Cancelled
+		searchDataImport.Finalised = resource.Finalised
+		searchDataImport.Published = resource.Published
+		searchDataImport.ProvisionalDate = resource.ProvisionalDate
+		searchDataImport.DateChanges = resource.DateChanges
+	}
+	return searchDataImport
+}

--- a/models/mapper_resource_test.go
+++ b/models/mapper_resource_test.go
@@ -1,0 +1,82 @@
+package models
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+var (
+	testReleaseDate        = "2010-02-01T00:00:00Z"
+	testTitle              = "A Release with A Change Notice for a Future Date"
+	testSummary            = "latest summary"
+	testCanonicalTopic     = "latest canonical topic"
+	testTopics             = []string{"4972", "1245"}
+	testURI                = "/peoplepopulationandcommunity/healthandsocialcare/drugusealcoholandsmoking"
+	testURIOld             = "an/old/uri"
+	testEdition            = "latest edition"
+	testContentTypeRelease = "release"
+	testCDID               = "A321B"
+	testDatasetID          = "ASELECTIONOFNUMBERSANDLETTERS456"
+	testMetaDescription    = "latest description"
+	testDateChanges        = []ReleaseDateDetails{
+		{
+			ChangeNotice: "a change_notice",
+			Date:         "2059-07-01T12:07:20Z",
+		},
+	}
+	testProvisionalDate = "March 1991"
+	testLanguage        = "latest language"
+	testSurvey          = "latest survey"
+)
+
+func TestMapResourceToSearchDataImport(t *testing.T) {
+	Convey("Given a search content update resource", t, func() {
+		searchContentUpdate := SearchContentUpdate{
+			CanonicalTopic:  testCanonicalTopic,
+			CDID:            testCDID,
+			ContentType:     testContentTypeRelease,
+			DatasetID:       testDatasetID,
+			Edition:         testEdition,
+			Language:        testLanguage,
+			MetaDescription: testMetaDescription,
+			ReleaseDate:     testReleaseDate,
+			Summary:         testSummary,
+			Survey:          testSurvey,
+			Title:           testTitle,
+			Topics:          testTopics,
+			URI:             testURI,
+			URIOld:          testURIOld,
+			// These fields are only used for ContentType=release
+			Cancelled:       false,
+			DateChanges:     testDateChanges,
+			Finalised:       true,
+			ProvisionalDate: testProvisionalDate,
+			Published:       false,
+		}
+
+		Convey("Then all expected fields are mapped to a SearchDataImport model", func() {
+			searchDataImport := MapResourceToSearchDataImport(searchContentUpdate)
+			So(searchDataImport, ShouldResemble, SearchDataImport{
+				URI:             testURI,
+				Edition:         testEdition,
+				DataType:        testContentTypeRelease,
+				CDID:            testCDID,
+				DatasetID:       testDatasetID,
+				MetaDescription: testMetaDescription,
+				ReleaseDate:     testReleaseDate,
+				Summary:         testSummary,
+				Title:           testTitle,
+				Topics:          testTopics,
+				DateChanges:     testDateChanges,
+				Cancelled:       false,
+				Finalised:       true,
+				ProvisionalDate: testProvisionalDate,
+				CanonicalTopic:  testCanonicalTopic,
+				Published:       false,
+				Language:        testLanguage,
+				Survey:          testSurvey,
+			})
+		})
+	})
+}


### PR DESCRIPTION
### What

In my work on another repo, the Search Reindex Batch service, my ticket specified "Solution should reuse mapping from dp-search-data-extractor". This is the ticket:

https://jira.ons.gov.uk/browse/DIS-1784

However, the mapping could not be reused as it was contained within a handler. These changes refactor the mapping so that it could potentially be reused by the Search Reindex Batch service and others.

### How to review

Check that the Search Data Extractor still works correctly and its tests pass.

### Who can review

!me