### PR TITLE
Remove search_index from search-content-update kafka message

### DIFF
--- a/handler/search_content_handler.go
+++ b/handler/search_content_handler.go
@@ -61,6 +61,7 @@ func (h *SearchContentHandler) Handle(ctx context.Context, _ int, msg kafka.Mess
 
 func (h *SearchContentHandler) sendSearchDataImported(ctx context.Context, resource models.SearchContentUpdate) error {
 	searchDataImport := models.MapResourceToSearchDataImport(resource)
+	searchDataImport.SearchIndex = "ons"
 
 	// Marshall Avro and sending message
 	if err := h.ImportProducer.Send(schema.SearchDataImportEvent, searchDataImport); err != nil {
@@ -74,6 +75,7 @@ func (h *SearchContentHandler) sendSearchDataImported(ctx context.Context, resou
 
 func (h *SearchContentHandler) sendSearchContentDeleted(ctx context.Context, resource models.SearchContentUpdate) error {
 	deleteEvent := models.MapResourceToSearchContentDelete(resource)
+	deleteEvent.SearchIndex = "ons"
 
 	if err := h.DeleteProducer.Send(schema.SearchContentDeletedEvent, deleteEvent); err != nil {
 		log.Error(ctx, "error while attempting to send SearchContentDeleted event", err)

--- a/handler/search_content_handler.go
+++ b/handler/search_content_handler.go
@@ -61,7 +61,7 @@ func (h *SearchContentHandler) Handle(ctx context.Context, _ int, msg kafka.Mess
 
 func (h *SearchContentHandler) sendSearchDataImported(ctx context.Context, resource models.SearchContentUpdate) error {
 	searchDataImport := models.MapResourceToSearchDataImport(resource)
-	searchDataImport.SearchIndex = "ons"
+	searchDataImport.SearchIndex = OnsSearchIndex
 
 	// Marshall Avro and sending message
 	if err := h.ImportProducer.Send(schema.SearchDataImportEvent, searchDataImport); err != nil {
@@ -75,7 +75,7 @@ func (h *SearchContentHandler) sendSearchDataImported(ctx context.Context, resou
 
 func (h *SearchContentHandler) sendSearchContentDeleted(ctx context.Context, resource models.SearchContentUpdate) error {
 	deleteEvent := models.MapResourceToSearchContentDelete(resource)
-	deleteEvent.SearchIndex = "ons"
+	deleteEvent.SearchIndex = OnsSearchIndex
 
 	if err := h.DeleteProducer.Send(schema.SearchContentDeletedEvent, deleteEvent); err != nil {
 		log.Error(ctx, "error while attempting to send SearchContentDeleted event", err)

--- a/handler/search_content_handler_test.go
+++ b/handler/search_content_handler_test.go
@@ -55,7 +55,6 @@ func TestSearchContentHandler_Handle(t *testing.T) {
 					URI:         "/uri/without/old",
 					Title:       "No Old URI",
 					ContentType: "article",
-					SearchIndex: "ons",
 					TraceID:     "trace1234",
 				}
 
@@ -98,8 +97,7 @@ func TestSearchContentHandler_Handle(t *testing.T) {
 							Date:         "2023-01-01",
 						},
 					},
-					SearchIndex: "ons",
-					TraceID:     "trace1234",
+					TraceID: "trace1234",
 				}
 
 				msg := createSearchContentMessage(expectedEvent)

--- a/models/event.go
+++ b/models/event.go
@@ -39,7 +39,7 @@ type SearchDataImport struct {
 	Dimensions      []Dimension          `avro:"dimensions"`
 }
 
-// ReleaseDateChange represent a date change of a release
+// ReleaseDateDetails represents a date change of a release
 type ReleaseDateDetails struct {
 	ChangeNotice string `avro:"change_notice"`
 	Date         string `avro:"previous_date"`
@@ -74,7 +74,6 @@ type SearchContentUpdate struct {
 	Language        string   `avro:"language"`
 	MetaDescription string   `avro:"meta_description"`
 	ReleaseDate     string   `avro:"release_date"`
-	SearchIndex     string   `avro:"search_index"`
 	Summary         string   `avro:"summary"`
 	Survey          string   `avro:"survey"`
 	Title           string   `avro:"title"`

--- a/models/mapper_resource.go
+++ b/models/mapper_resource.go
@@ -18,7 +18,6 @@ func MapResourceToSearchDataImport(resource SearchContentUpdate) SearchDataImpor
 		CanonicalTopic:  resource.CanonicalTopic,
 		Topics:          []string{},
 		TraceID:         resource.TraceID,
-		SearchIndex:     resource.SearchIndex,
 	}
 
 	// Assign topics only if they're not nil
@@ -39,9 +38,8 @@ func MapResourceToSearchDataImport(resource SearchContentUpdate) SearchDataImpor
 // MapResourceToSearchContentDelete Performs default mapping of a SearchContentUpdate struct to a SearchContentDeleted struct.
 func MapResourceToSearchContentDelete(resource SearchContentUpdate) SearchContentDeleted {
 	searchContentDeleted := SearchContentDeleted{
-		URI:         resource.URIOld,
-		TraceID:     resource.TraceID,
-		SearchIndex: resource.SearchIndex,
+		URI:     resource.URIOld,
+		TraceID: resource.TraceID,
 	}
 	return searchContentDeleted
 }

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -95,7 +95,6 @@ var searchContentUpdate = `{
     {"name": "language", "type": "string", "default": ""},
     {"name": "meta_description", "type": "string", "default": ""},
     {"name": "release_date", "type": "string", "default": ""},
-    {"name": "search_index", "type": "string", "default": ""},
     {"name": "summary", "type": "string", "default": ""},
     {"name": "survey", "type": "string", "default": ""},
     {"name": "title", "type": "string", "default": ""},

--- a/specification.yml
+++ b/specification.yml
@@ -102,9 +102,6 @@ components:
           job_id:
             type: string
             description: Job ID for use with reindex pipeline
-          search_index:
-            type: string
-            description: Specific search index ID for use with reindex pipeline
           trace_id:
             type: string
             description: Trace ID for OTEL tracing


### PR DESCRIPTION
### What

Jira ticket: https://officefornationalstatistics.atlassian.net/jira/software/c/projects/DIS/boards/1824?selectedIssue=DIS-3620

The search_index field has been removed from the search-content-update message, which is consumed by the service. Instead of using that field it now just sets the search_index fields of the search-data-import and search-data-deleted events to a fixed value.

### How to review

Check that it looks ok and the tests pass. You could also try running it in the Search Stack.

### Who can review

Anyone.