### PR TITLE
add release date to taxonomy landing page

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.26.4-bookworm
+    tag: 1.26.5-bookworm
 
 inputs:
   - name: dp-search-data-extractor

--- a/ci/component.yml
+++ b/ci/component.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: onsdigital/dp-concourse-tools-docker-go
-    tag: 1.26.4-dind-28
+    tag: 1.26.5-dind-28
 
 inputs:
   - name: dp-search-data-extractor

--- a/ci/lint.yml
+++ b/ci/lint.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: onsdigital/dp-concourse-tools-node-go
-    tag: 1.26.4-bookworm-node-24
+    tag: 1.26.5-bookworm-node-24
 
 inputs:
   - name: dp-search-data-extractor

--- a/ci/unit.yml
+++ b/ci/unit.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.26.4-bookworm
+    tag: 1.26.5-bookworm
 
 inputs:
   - name: dp-search-data-extractor

--- a/models/mapper_legacy.go
+++ b/models/mapper_legacy.go
@@ -3,12 +3,15 @@ package models
 import (
 	"context"
 	"strings"
+	"time"
 
 	"github.com/ONSdigital/log.go/v2/log"
 )
 
 const (
-	ReleaseDataType = "release"
+	ReleaseDataType             = "release"
+	TaxonomyLandingPageDataType = "taxonomy_landing_page"
+	DateFormat                  = "2006-01-02"
 )
 
 // MapZebedeeDataToSearchDataImport Performs default mapping of zebedee data to a SearchDataImport struct.
@@ -46,6 +49,11 @@ func MapZebedeeDataToSearchDataImport(zebedeeData ZebedeeData, keywordsLimit int
 		searchData.Survey = zebedeeData.Description.Survey
 		searchData.Language = zebedeeData.Description.Language
 		searchData.CanonicalTopic = zebedeeData.Description.CanonicalTopic
+	}
+	if zebedeeData.DataType == TaxonomyLandingPageDataType {
+		searchData.ReleaseDate = time.Now().Format(DateFormat)
+	} else {
+		searchData.ReleaseDate = zebedeeData.Description.ReleaseDate
 	}
 
 	return searchData

--- a/models/mapper_legacy_test.go
+++ b/models/mapper_legacy_test.go
@@ -2,6 +2,7 @@ package models_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/ONSdigital/dp-search-data-extractor/models"
 	. "github.com/smartystreets/goconvey/convey"
@@ -306,6 +307,58 @@ func TestValidate_WithEmptytopicsSize0(t *testing.T) {
 			actual := models.ValidateTopics([]string{})
 			Convey("Then topics should be populated with an string array of size 0", func() {
 				So(actual, ShouldResemble, []string{})
+			})
+		})
+	})
+}
+
+func TestMapZebedeeDataToSearchDataImport_TaxonomyLandingPage(t *testing.T) {
+	Convey("Given some valid zebedee data with taxonomy_landing_page data type", t, func() {
+		zebedeeData := models.ZebedeeData{
+			UID:      someTitle,
+			URI:      someURI,
+			DataType: models.TaxonomyLandingPageDataType,
+			Description: models.Description{
+				CDID:            someCDID,
+				DatasetID:       someDatasetID,
+				Keywords:        []string{somekeyword0, somekeyword1},
+				MetaDescription: someMetaDescription,
+				ReleaseDate:     someReleaseDate,
+				Summary:         someSummary,
+				Title:           someTitle,
+				Topics:          []string{sometopic0, sometopic1},
+			},
+		}
+		Convey("And mapped with a default keywords limit", func() {
+			result := models.MapZebedeeDataToSearchDataImport(zebedeeData, -1)
+			Convey("Then the release date should be set to today's date regardless of the description release date", func() {
+				So(result.ReleaseDate, ShouldEqual, time.Now().Format(models.DateFormat))
+			})
+		})
+	})
+}
+
+func TestMapZebedeeDataToSearchDataImport_NonTaxonomyLandingPage_UsesDescriptionReleaseDate(t *testing.T) {
+	Convey("Given some valid zebedee data with a non-taxonomy_landing_page data type", t, func() {
+		zebedeeData := models.ZebedeeData{
+			UID:      someTitle,
+			URI:      someURI,
+			DataType: "article",
+			Description: models.Description{
+				CDID:            someCDID,
+				DatasetID:       someDatasetID,
+				Keywords:        []string{somekeyword0},
+				MetaDescription: someMetaDescription,
+				ReleaseDate:     someReleaseDate,
+				Summary:         someSummary,
+				Title:           someTitle,
+				Topics:          []string{sometopic0},
+			},
+		}
+		Convey("And mapped with a default keywords limit", func() {
+			result := models.MapZebedeeDataToSearchDataImport(zebedeeData, -1)
+			Convey("Then the release date should come from the zebedee description", func() {
+				So(result.ReleaseDate, ShouldEqual, someReleaseDate)
 			})
 		})
 	})


### PR DESCRIPTION
### What

add release date to taxonomy landing page
^ [this is to allow the topic page to show up in search](https://officefornationalstatistics.atlassian.net/browse/DIS-4989?atlOrigin=eyJpIjoiYjYwMTA4YWNkNDA4NGU1OThlYWQzNjZmNDIyMzE3MTMiLCJwIjoiaiJ9)

### How to review

sense check
test with the search stack in`dp-compose`

### Who can review

!me