### PR TITLE
Release 1.15.0

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.26.4-bookworm
+    tag: 1.26.5-bookworm
 
 inputs:
   - name: dp-search-data-extractor

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.26.3-bookworm
+    tag: 1.26.4-bookworm
 
 inputs:
   - name: dp-search-data-extractor

--- a/ci/component.yml
+++ b/ci/component.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: onsdigital/dp-concourse-tools-docker-go
-    tag: 1.26.3-dind-28
+    tag: 1.26.4-dind-28
 
 inputs:
   - name: dp-search-data-extractor

--- a/ci/component.yml
+++ b/ci/component.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: onsdigital/dp-concourse-tools-docker-go
-    tag: 1.26.4-dind-28
+    tag: 1.26.5-dind-28
 
 inputs:
   - name: dp-search-data-extractor

--- a/ci/lint.yml
+++ b/ci/lint.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: onsdigital/dp-concourse-tools-node-go
-    tag: 1.26.4-bookworm-node-24
+    tag: 1.26.5-bookworm-node-24
 
 inputs:
   - name: dp-search-data-extractor

--- a/ci/lint.yml
+++ b/ci/lint.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: onsdigital/dp-concourse-tools-node-go
-    tag: 1.26.3-bookworm-node-20
+    tag: 1.26.4-bookworm-node-24
 
 inputs:
   - name: dp-search-data-extractor

--- a/ci/unit.yml
+++ b/ci/unit.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.26.4-bookworm
+    tag: 1.26.5-bookworm
 
 inputs:
   - name: dp-search-data-extractor

--- a/ci/unit.yml
+++ b/ci/unit.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.26.3-bookworm
+    tag: 1.26.4-bookworm
 
 inputs:
   - name: dp-search-data-extractor

--- a/models/mapper_legacy.go
+++ b/models/mapper_legacy.go
@@ -9,6 +9,7 @@ import (
 
 const (
 	ReleaseDataType = "release"
+	ArticleDataType = "article"
 )
 
 // MapZebedeeDataToSearchDataImport Performs default mapping of zebedee data to a SearchDataImport struct.
@@ -46,6 +47,11 @@ func MapZebedeeDataToSearchDataImport(zebedeeData ZebedeeData, keywordsLimit int
 		searchData.Survey = zebedeeData.Description.Survey
 		searchData.Language = zebedeeData.Description.Language
 		searchData.CanonicalTopic = zebedeeData.Description.CanonicalTopic
+	}
+	if zebedeeData.DataType == ArticleDataType {
+		if searchData.Summary == "" {
+			searchData.Summary = zebedeeData.Description.Abstract
+		}
 	}
 
 	return searchData

--- a/models/mapper_legacy_test.go
+++ b/models/mapper_legacy_test.go
@@ -9,6 +9,7 @@ import (
 
 const (
 	someRelease          = "release"
+	someArticle          = "article"
 	someCDID             = "CDID"
 	someChangeNotice     = "Delay on publication"
 	someChangeNoticeDate = "2021-12-14"
@@ -24,6 +25,8 @@ const (
 	someProvisionalDate = "2021-12-12"
 	someReleaseDate     = "2021-12-13"
 	someSummary         = "Some Amazing Summary"
+	emptySummary        = ""
+	someAbstract        = "Some Interesting Abstract"
 	someTitle           = "Some Incredible Title"
 	someSurvey          = "Some survey"
 	someLanguage        = "some language"
@@ -57,6 +60,7 @@ func TestMapZebedeeDataToSearchDataImport(t *testing.T) {
 				Published:       true,
 				ReleaseDate:     someReleaseDate,
 				Summary:         someSummary,
+				Abstract:        someAbstract,
 				Title:           someTitle,
 				Topics:          []string{sometopic0, sometopic1},
 				Survey:          someSurvey,
@@ -86,11 +90,21 @@ func TestMapZebedeeDataToSearchDataImport(t *testing.T) {
 				Published:       true,
 				ReleaseDate:     someReleaseDate,
 				Summary:         someSummary,
+				Abstract:        someAbstract,
 				Title:           someTitle,
 				Topics:          []string{sometopic0, sometopic1},
 				Survey:          someSurvey,
 				Language:        someLanguage,
 				CanonicalTopic:  canonicalTopic,
+			},
+		}
+		zebedeeDataWithEmptySummary := models.ZebedeeData{
+			UID:      someTitle,
+			URI:      someURI,
+			DataType: someArticle,
+			Description: models.Description{
+				Summary:  emptySummary,
+				Abstract: someAbstract,
 			},
 		}
 		Convey("And mapped with a default keywords limit when edition is present", func() {
@@ -183,6 +197,12 @@ func TestMapZebedeeDataToSearchDataImport(t *testing.T) {
 				So(result.Keywords, ShouldHaveLength, 2)
 				So(result.Keywords[0], ShouldResemble, somekeyword0)
 				So(result.Keywords[1], ShouldResemble, somekeyword1)
+			})
+		})
+		Convey("And mapped with zebedee returning an article with an empty summary field", func() {
+			result := models.MapZebedeeDataToSearchDataImport(zebedeeDataWithEmptySummary, -1)
+			Convey("Then the abstract field value should be mapped to the summary instead", func() {
+				So(result.Summary, ShouldResemble, someAbstract)
 			})
 		})
 	})

--- a/models/zebedee.go
+++ b/models/zebedee.go
@@ -23,6 +23,7 @@ type Description struct {
 	Published       bool     `json:"published,omitempty"`
 	ReleaseDate     string   `json:"releaseDate"`
 	Summary         string   `json:"summary"`
+	Abstract        string   `json:"_abstract"`
 	Title           string   `json:"title"`
 	Topics          []string `json:"secondaryTopics,omitempty"`
 	Language        string   `json:"language,omitempty"`


### PR DESCRIPTION
# What has changed
These are the changes in this release:

- upgrade dependencies to node 24 - https://github.com/ONSdigital/dp-search-data-extractor/pull/164 - @tjoluotch 
- Map abstract field to summary field for articles - https://github.com/ONSdigital/dp-search-data-extractor/pull/166 - @cookel2 

# How to review
<!--- Describe in detail how you tested your changes. -->
Check only expected commits present and tests pass

# Who can review
<!--- Give names if specific reviewers required, otherwise say "Anyone but me". -->
Anyone but me