### PR TITLE
add release date to product page

### DIFF
--- a/models/mapper_legacy.go
+++ b/models/mapper_legacy.go
@@ -3,13 +3,10 @@ package models
 import (
 	"context"
 	"strings"
+	"time"
 
+	zebedeeclient "github.com/ONSdigital/dp-api-clients-go/v2/zebedee"
 	"github.com/ONSdigital/log.go/v2/log"
-)
-
-const (
-	ReleaseDataType = "release"
-	ArticleDataType = "article"
 )
 
 // MapZebedeeDataToSearchDataImport Performs default mapping of zebedee data to a SearchDataImport struct.
@@ -32,7 +29,7 @@ func MapZebedeeDataToSearchDataImport(zebedeeData ZebedeeData, keywordsLimit int
 	if zebedeeData.Description.Edition != "" {
 		searchData.Edition = zebedeeData.Description.Edition
 	}
-	if zebedeeData.DataType == ReleaseDataType {
+	if zebedeeData.DataType == zebedeeclient.PageTypeRelease {
 		logData := log.Data{
 			"zebedeeRCData": zebedeeData,
 		}
@@ -48,12 +45,16 @@ func MapZebedeeDataToSearchDataImport(zebedeeData ZebedeeData, keywordsLimit int
 		searchData.Language = zebedeeData.Description.Language
 		searchData.CanonicalTopic = zebedeeData.Description.CanonicalTopic
 	}
-	if zebedeeData.DataType == ArticleDataType {
+	if zebedeeData.DataType == zebedeeclient.PageTypeArticle {
 		if searchData.Summary == "" {
 			searchData.Summary = zebedeeData.Description.Abstract
 		}
 	}
-
+	// If the data type is a product page (topic page), then we set release date to "now" so it surfaces in search
+	// results. "Now" is used so if/when product pages are edited, they will have accurate release dates.
+	if zebedeeData.DataType == zebedeeclient.PageTypeProductPage {
+		searchData.ReleaseDate = time.Now().UTC().Format(time.RFC3339)
+	}
 	return searchData
 }
 

--- a/models/mapper_legacy_test.go
+++ b/models/mapper_legacy_test.go
@@ -2,7 +2,9 @@ package models_test
 
 import (
 	"testing"
+	"time"
 
+	zebedeeclient "github.com/ONSdigital/dp-api-clients-go/v2/zebedee"
 	"github.com/ONSdigital/dp-search-data-extractor/models"
 	. "github.com/smartystreets/goconvey/convey"
 )
@@ -326,6 +328,58 @@ func TestValidate_WithEmptytopicsSize0(t *testing.T) {
 			actual := models.ValidateTopics([]string{})
 			Convey("Then topics should be populated with an string array of size 0", func() {
 				So(actual, ShouldResemble, []string{})
+			})
+		})
+	})
+}
+
+func TestMapZebedeeDataToSearchDataImport_ProductPage(t *testing.T) {
+	Convey("Given some valid zebedee data with product_page data type", t, func() {
+		zebedeeData := models.ZebedeeData{
+			UID:      someTitle,
+			URI:      someURI,
+			DataType: zebedeeclient.PageTypeProductPage,
+			Description: models.Description{
+				CDID:            someCDID,
+				DatasetID:       someDatasetID,
+				Keywords:        []string{somekeyword0, somekeyword1},
+				MetaDescription: someMetaDescription,
+				ReleaseDate:     someReleaseDate,
+				Summary:         someSummary,
+				Title:           someTitle,
+				Topics:          []string{sometopic0, sometopic1},
+			},
+		}
+		Convey("And mapped with a default keywords limit", func() {
+			result := models.MapZebedeeDataToSearchDataImport(zebedeeData, -1)
+			Convey("Then the release date should be set to today's date regardless of the input release date", func() {
+				So(result.ReleaseDate, ShouldEqual, time.Now().UTC().Format(time.RFC3339))
+			})
+		})
+	})
+}
+
+func TestMapZebedeeDataToSearchDataImport_NonProductPage_UsesDescriptionReleaseDate(t *testing.T) {
+	Convey("Given some valid zebedee data with a non-product_page data type", t, func() {
+		zebedeeData := models.ZebedeeData{
+			UID:      someTitle,
+			URI:      someURI,
+			DataType: "article",
+			Description: models.Description{
+				CDID:            someCDID,
+				DatasetID:       someDatasetID,
+				Keywords:        []string{somekeyword0},
+				MetaDescription: someMetaDescription,
+				ReleaseDate:     someReleaseDate,
+				Summary:         someSummary,
+				Title:           someTitle,
+				Topics:          []string{sometopic0},
+			},
+		}
+		Convey("And mapped with a default keywords limit", func() {
+			result := models.MapZebedeeDataToSearchDataImport(zebedeeData, -1)
+			Convey("Then the release date should come from the zebedee description", func() {
+				So(result.ReleaseDate, ShouldEqual, someReleaseDate)
 			})
 		})
 	})

--- a/models/mapper_resource.go
+++ b/models/mapper_resource.go
@@ -1,5 +1,7 @@
 package models
 
+import zebedeeclient "github.com/ONSdigital/dp-api-clients-go/v2/zebedee"
+
 // MapResourceToSearchDataImport Performs default mapping of a SearchContentUpdate struct to a SearchDataImport struct.
 func MapResourceToSearchDataImport(resource SearchContentUpdate) SearchDataImport {
 	searchDataImport := SearchDataImport{
@@ -25,7 +27,7 @@ func MapResourceToSearchDataImport(resource SearchContentUpdate) SearchDataImpor
 		searchDataImport.Topics = resource.Topics
 	}
 
-	if resource.ContentType == ReleaseDataType {
+	if resource.ContentType == zebedeeclient.PageTypeRelease {
 		searchDataImport.Cancelled = resource.Cancelled
 		searchDataImport.Finalised = resource.Finalised
 		searchDataImport.Published = resource.Published


### PR DESCRIPTION
### What

add release date to product page, to surface zebedee topic pages in search

### How to review

sense check

**optionally**
- pull this branch
- do a `replace` in `dp-search-reindex-batch`
- ensure that `EnableZebedeeReindex` is set to `true` in `dp-search-reindex-batch`
- export service auth token for sandbox in both `dp-search-reindex-batch` and `dp-search-data-extractor`
- in the search stack, export the sandbox dataset-api auth token
- run the search stack, with the `BACKEND WITH MAPPINGS` default.env option
- port forward to both zebedee and the dataset-api in sandbox:
```
dp ssh sandbox publishing 1 -p 8082:localhost:10050
```
```
dp ssh sandbox publishing 2 -p 22000:localhost:10400
```

- run `make debug` in `dp-search-reindex-batch`
- search for `balance of payments` -> the topic page should now be there

### Who can review

!me